### PR TITLE
add realisation cfg.Unit

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -449,16 +449,22 @@ func ParseField(v reflect.Value, vField reflect.Value, tField reflect.StructFiel
 			finalField.SetInt(int64(value))
 
 		case "unit":
-			value, err := strconv.Atoi(strings.Split(vField.String(), " ")[0])
-			if err != nil {
-				return fmt.Errorf("could not parse number, err: %s", err.Error())
+			parts := strings.Split(vField.String(), " ")
+			if len(parts) != 2 {
+				return fmt.Errorf("invalid data format, the string must contain 2 parts separated by a space")
 			}
-			size := strings.TrimPrefix(vField.String(), strings.Split(vField.String(), " ")[0])
-			size = strings.ToLower(strings.TrimSpace(size))
-			if multiplier, ok := UnitAlias[size]; ok {
+			value, err := strconv.Atoi(parts[0])
+			if err != nil {
+				return fmt.Errorf(`can't parse uint: "%s" is not a number`, parts[0])
+			}
+			if value < 0 {
+				return fmt.Errorf("value must be positive")
+			}
+			alias := strings.ToLower(strings.TrimSpace(parts[1]))
+			if multiplier, ok := UnitAlias[alias]; ok {
 				finalField.SetUint(uint64(value * multiplier))
 			} else {
-				return fmt.Errorf("unexpected alias %s", size)
+				return fmt.Errorf(`unexpected alias "%s"`, alias)
 			}
 
 		default:

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -451,7 +451,7 @@ func ParseField(v reflect.Value, vField reflect.Value, tField reflect.StructFiel
 		case "unit":
 			value, err := strconv.Atoi(strings.Split(vField.String(), " ")[0])
 			if err != nil {
-				return fmt.Errorf("could not parse number %d, err: %w", value, err)
+				return fmt.Errorf("could not parse number %d, err: %s", value, err.Error())
 			}
 			size := strings.TrimPrefix(vField.String(), strings.Split(vField.String(), " ")[0])
 			size = strings.TrimSpace(size)

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -448,6 +448,20 @@ func ParseField(v reflect.Value, vField reflect.Value, tField reflect.StructFiel
 			}
 			finalField.SetInt(int64(value))
 
+		case "unit":
+			value, err := strconv.Atoi(strings.Split(vField.String(), " ")[0])
+			if err != nil {
+				return fmt.Errorf("could not parse number %d, err: %s", value, err.Error())
+			}
+			size := strings.TrimPrefix(vField.String(), strings.Split(vField.String(), " ")[0])
+			size = strings.TrimSpace(size)
+
+			if multiplier, ok := UnitAlias[size]; ok {
+				finalField.SetUint(uint64(value * multiplier))
+			} else {
+				return fmt.Errorf("unexpected alias %s", size)
+			}
+
 		default:
 			return fmt.Errorf("unsupported parse type %q for field %s", tag, tField.Name)
 		}

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -448,7 +448,7 @@ func ParseField(v reflect.Value, vField reflect.Value, tField reflect.StructFiel
 			}
 			finalField.SetInt(int64(value))
 
-		case "unit":
+		case "data_unit":
 			parts := strings.Split(vField.String(), " ")
 			if len(parts) != 2 {
 				return fmt.Errorf("invalid data format, the string must contain 2 parts separated by a space")
@@ -461,7 +461,7 @@ func ParseField(v reflect.Value, vField reflect.Value, tField reflect.StructFiel
 				return fmt.Errorf("value must be positive")
 			}
 			alias := strings.ToLower(strings.TrimSpace(parts[1]))
-			if multiplier, ok := UnitAlias[alias]; ok {
+			if multiplier, ok := DataUnitAliases[alias]; ok {
 				finalField.SetUint(uint64(value * multiplier))
 			} else {
 				return fmt.Errorf(`unexpected alias "%s"`, alias)

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -451,10 +451,10 @@ func ParseField(v reflect.Value, vField reflect.Value, tField reflect.StructFiel
 		case "unit":
 			value, err := strconv.Atoi(strings.Split(vField.String(), " ")[0])
 			if err != nil {
-				return fmt.Errorf("could not parse number %d, err: %s", value, err.Error())
+				return fmt.Errorf("could not parse number, err: %s", err.Error())
 			}
 			size := strings.TrimPrefix(vField.String(), strings.Split(vField.String(), " ")[0])
-			size = strings.TrimSpace(size)
+			size = strings.ToLower(strings.TrimSpace(size))
 			if multiplier, ok := UnitAlias[size]; ok {
 				finalField.SetUint(uint64(value * multiplier))
 			} else {

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -451,11 +451,10 @@ func ParseField(v reflect.Value, vField reflect.Value, tField reflect.StructFiel
 		case "unit":
 			value, err := strconv.Atoi(strings.Split(vField.String(), " ")[0])
 			if err != nil {
-				return fmt.Errorf("could not parse number %d, err: %s", value, err.Error())
+				return fmt.Errorf("could not parse number %d, err: %w", value, err)
 			}
 			size := strings.TrimPrefix(vField.String(), strings.Split(vField.String(), " ")[0])
 			size = strings.TrimSpace(size)
-
 			if multiplier, ok := UnitAlias[size]; ok {
 				finalField.SetUint(uint64(value * multiplier))
 			} else {

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -144,52 +144,28 @@ func TestParseExpressionConst(t *testing.T) {
 	assert.Equal(t, 10, s.T_, "wrong value")
 }
 
-func TestParseUnitNumber(t *testing.T) {
-	s := &strUnit{T: "10"}
-	err := Parse(s, nil)
-
-	assert.Errorf(t, err, "shouldn't be an error")
-	assert.Equal(t, uint(0), s.T_, "wrong value")
+func TestParseUnitBadPractice(t *testing.T) {
+	TestTable := []*strUnit{
+		{T: "10"}, {T: " 10"}, {T: "10 "},
+		{T: "MB"}, {T: " MB"}, {T: " MB"},
+		{T: " 1 B"}, {T: "something"},
+	}
+	for i := range TestTable {
+		err := Parse(TestTable[i], nil)
+		assert.Error(t, err, "shouldn't be an error")
+		assert.Equal(t, uint(0), TestTable[i].T_, "wrong value")
+	}
 }
 
-func TestParseUnitNumberWithSpace(t *testing.T) {
-	s := &strUnit{T: "10 "}
-	err := Parse(s, nil)
-
-	assert.Errorf(t, err, "shouldn't be an error")
-	assert.Equal(t, uint(0), s.T_, "wrong value")
-}
-
-func TestParseUnitNumberWithAlias(t *testing.T) {
-	s := &strUnit{T: "10 MB"}
-	err := Parse(s, nil)
-
-	assert.Nil(t, err, "shouldn't be an error")
-	assert.Equal(t, uint(10000000), s.T_, "wrong value")
-}
-
-func TestParseUnitSpacePlusNumberWithAlias(t *testing.T) {
-	s := &strUnit{T: " 10 MB"}
-	err := Parse(s, nil)
-
-	assert.Error(t, err, "shouldn't be an error")
-	assert.Equal(t, uint(0), s.T_, "wrong value")
-}
-
-func TestParseUnitNumberWithAliasPlusSpace(t *testing.T) {
-	s := &strUnit{T: "10 MB "}
-	err := Parse(s, nil)
-
-	assert.Nil(t, err, "shouldn't be an error")
-	assert.Equal(t, uint(10000000), s.T_, "wrong value")
-}
-
-func TestParseUnitEmpty(t *testing.T) {
-	s := &strUnit{T: ""}
-	err := Parse(s, nil)
-
-	assert.Errorf(t, err, "should be an error")
-	assert.Equal(t, uint(0), s.T_, "wrong value")
+func TestParseUnitGoodPractice(t *testing.T) {
+	TestTable := []*strUnit{
+		{T: "1 B"}, {T: "1  B"}, {T: "1 B "}, {T: "1  B "},
+	}
+	for i := range TestTable {
+		err := Parse(TestTable[i], nil)
+		assert.Nil(t, err, "shouldn't be an error")
+		assert.Equal(t, uint(1), TestTable[i].T_, "wrong value")
+	}
 }
 
 func TestParseFieldSelectorSimple(t *testing.T) {

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -49,8 +49,8 @@ type strExpression struct {
 	T_ int
 }
 
-type strUnit struct {
-	T  string `parse:"unit"`
+type strDataUnit struct {
+	T  string `parse:"data_unit"`
 	T_ uint
 }
 
@@ -145,126 +145,126 @@ func TestParseExpressionConst(t *testing.T) {
 	assert.Equal(t, 10, s.T_, "wrong value")
 }
 
-func TestParseUnitInvalid(t *testing.T) {
+func TestParseDataUnitInvalid(t *testing.T) {
 	TestList := []struct {
-		strUnit       *strUnit
+		strDataUnit   *strDataUnit
 		ExpectedError error
 		ExpectedValue uint
 	}{
 		{
-			strUnit:       &strUnit{T: "10"},
+			strDataUnit:   &strDataUnit{T: "10"},
 			ExpectedError: errors.New("invalid data format, the string must contain 2 parts separated by a space"),
 			ExpectedValue: 0,
 		},
 		{
-			strUnit:       &strUnit{T: " 10"},
+			strDataUnit:   &strDataUnit{T: " 10"},
 			ExpectedError: errors.New(`can't parse uint: "" is not a number`),
 			ExpectedValue: 0,
 		},
 		{
-			strUnit:       &strUnit{T: "10 "},
+			strDataUnit:   &strDataUnit{T: "10 "},
 			ExpectedError: errors.New(`unexpected alias ""`),
 			ExpectedValue: 0,
 		},
 		{
-			strUnit:       &strUnit{T: " 1 MB"},
+			strDataUnit:   &strDataUnit{T: " 1 MB"},
 			ExpectedError: errors.New("invalid data format, the string must contain 2 parts separated by a space"),
 			ExpectedValue: 0,
 		},
 		{
-			strUnit:       &strUnit{T: " MB"},
+			strDataUnit:   &strDataUnit{T: " MB"},
 			ExpectedError: errors.New(`can't parse uint: "" is not a number`),
 			ExpectedValue: 0,
 		},
 		{
-			strUnit:       &strUnit{T: "MB "},
+			strDataUnit:   &strDataUnit{T: "MB "},
 			ExpectedError: errors.New(`can't parse uint: "MB" is not a number`),
 			ExpectedValue: 0,
 		},
 		{
-			strUnit:       &strUnit{T: "10 "},
+			strDataUnit:   &strDataUnit{T: "10 "},
 			ExpectedError: errors.New(`unexpected alias ""`),
 			ExpectedValue: 0,
 		},
 		{
-			strUnit:       &strUnit{T: "something"},
+			strDataUnit:   &strDataUnit{T: "something"},
 			ExpectedError: errors.New("invalid data format, the string must contain 2 parts separated by a space"),
 			ExpectedValue: 0,
 		},
 		{
-			strUnit:       &strUnit{T: "some thing"},
+			strDataUnit:   &strDataUnit{T: "some thing"},
 			ExpectedError: errors.New(`can't parse uint: "some" is not a number`),
 			ExpectedValue: 0,
 		},
 		{
-			strUnit:       &strUnit{T: ""},
+			strDataUnit:   &strDataUnit{T: ""},
 			ExpectedError: errors.New("invalid data format, the string must contain 2 parts separated by a space"),
 			ExpectedValue: 0,
 		},
 		{
-			strUnit:       &strUnit{T: "999999999999999999999 B"},
+			strDataUnit:   &strDataUnit{T: "999999999999999999999 B"},
 			ExpectedError: errors.New(`can't parse uint: "999999999999999999999" is not a number`),
 			ExpectedValue: 0,
 		},
 		{
-			strUnit:       &strUnit{T: "1  B"},
+			strDataUnit:   &strDataUnit{T: "1  B"},
 			ExpectedError: errors.New("invalid data format, the string must contain 2 parts separated by a space"),
 			ExpectedValue: 0,
 		},
 		{
-			strUnit:       &strUnit{T: "1 B "},
+			strDataUnit:   &strDataUnit{T: "1 B "},
 			ExpectedError: errors.New("invalid data format, the string must contain 2 parts separated by a space"),
 			ExpectedValue: 0,
 		},
 		{
-			strUnit:       &strUnit{T: "-1 PB"},
+			strDataUnit:   &strDataUnit{T: "-1 PB"},
 			ExpectedError: errors.New("value must be positive"),
 			ExpectedValue: 0,
 		},
 		// TODO: handle uint overflow situation
 		//{
-		//	strUnit:       &strUnit{T: "100000000000 PB"},
+		//	strDataUnit:       &strDataUnit{T: "100000000000 PB"},
 		//	ExpectedError: errors.New("uint overflowed on product 100000000000 and PB"),
 		//	ExpectedValue: 0,
 		//},
 	}
 	for i := range TestList {
-		err := Parse(TestList[i].strUnit, nil)
+		err := Parse(TestList[i].strDataUnit, nil)
 		assert.Equal(t, TestList[i].ExpectedError, err, "wrong error")
-		assert.Equal(t, uint(0), TestList[i].strUnit.T_, "wrong value")
+		assert.Equal(t, uint(0), TestList[i].strDataUnit.T_, "wrong value")
 	}
 }
 
-func TestParseUnitValid(t *testing.T) {
+func TestParseDataUnitValid(t *testing.T) {
 	TestList := []struct {
-		strUnit       *strUnit
+		strDataUnit   *strDataUnit
 		ExpectedValue uint
 	}{
 		{
-			strUnit:       &strUnit{T: "10 MB"},
+			strDataUnit:   &strDataUnit{T: "10 MB"},
 			ExpectedValue: 10000000,
 		},
 		{
-			strUnit:       &strUnit{T: "10 mB"},
+			strDataUnit:   &strDataUnit{T: "10 mB"},
 			ExpectedValue: 10000000,
 		},
 		{
-			strUnit:       &strUnit{T: "10 Mb"},
+			strDataUnit:   &strDataUnit{T: "10 Mb"},
 			ExpectedValue: 10000000,
 		},
 		{
-			strUnit:       &strUnit{T: "10 mb"},
+			strDataUnit:   &strDataUnit{T: "10 mb"},
 			ExpectedValue: 10000000,
 		},
 		{
-			strUnit:       &strUnit{T: "1 B"},
+			strDataUnit:   &strDataUnit{T: "1 B"},
 			ExpectedValue: 1,
 		},
 	}
 	for i := range TestList {
-		err := Parse(TestList[i].strUnit, nil)
+		err := Parse(TestList[i].strDataUnit, nil)
 		assert.Nil(t, err, "shouldn't be an error")
-		assert.Equal(t, TestList[i].ExpectedValue, TestList[i].strUnit.T_, "wrong value")
+		assert.Equal(t, TestList[i].ExpectedValue, TestList[i].strDataUnit.T_, "wrong value")
 	}
 }
 

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -144,27 +144,27 @@ func TestParseExpressionConst(t *testing.T) {
 	assert.Equal(t, 10, s.T_, "wrong value")
 }
 
-func TestParseUnitBadPractice(t *testing.T) {
-	TestTable := []*strUnit{
+func TestParseUnitInvalid(t *testing.T) {
+	TestList := []*strUnit{
 		{T: "10"}, {T: " 10"}, {T: "10 "},
 		{T: "MB"}, {T: " MB"}, {T: " MB"},
 		{T: " 1 B"}, {T: "something"}, {T: ""},
 	}
-	for i := range TestTable {
-		err := Parse(TestTable[i], nil)
+	for i := range TestList {
+		err := Parse(TestList[i], nil)
 		assert.Error(t, err, "shouldn't be an error")
-		assert.Equal(t, uint(0), TestTable[i].T_, "wrong value")
+		assert.Equal(t, uint(0), TestList[i].T_, "wrong value")
 	}
 }
 
-func TestParseUnitGoodPractice(t *testing.T) {
-	TestTable := []*strUnit{
+func TestParseUnit(t *testing.T) {
+	TestList := []*strUnit{
 		{T: "1 B"}, {T: "1  B"}, {T: "1 B "}, {T: "1  B "},
 	}
-	for i := range TestTable {
-		err := Parse(TestTable[i], nil)
+	for i := range TestList {
+		err := Parse(TestList[i], nil)
 		assert.Nil(t, err, "shouldn't be an error")
-		assert.Equal(t, uint(1), TestTable[i].T_, "wrong value")
+		assert.Equal(t, uint(1), TestList[i].T_, "wrong value")
 	}
 }
 

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -144,12 +144,36 @@ func TestParseExpressionConst(t *testing.T) {
 	assert.Equal(t, 10, s.T_, "wrong value")
 }
 
-func TestParseUnit(t *testing.T) {
+func TestParseUnitNumber(t *testing.T) {
+	s := &strUnit{T: "10"}
+	err := Parse(s, nil)
+
+	assert.Nil(t, err, "shouldn't be an error")
+	assert.Equal(t, uint(10), s.T_, "wrong value")
+}
+
+func TestParseUnitNumberWithSpace(t *testing.T) {
+	s := &strUnit{T: "10 "}
+	err := Parse(s, nil)
+
+	assert.Nil(t, err, "shouldn't be an error")
+	assert.Equal(t, uint(10), s.T_, "wrong value")
+}
+
+func TestParseUnitNumberWithAlias(t *testing.T) {
 	s := &strUnit{T: "10 MB"}
 	err := Parse(s, nil)
 
 	assert.Nil(t, err, "shouldn't be an error")
 	assert.Equal(t, uint(10000000), s.T_, "wrong value")
+}
+
+func TestParseUnitEmpty(t *testing.T) {
+	s := &strUnit{T: ""}
+	err := Parse(s, nil)
+
+	assert.Errorf(t, err, "should be an error")
+	assert.Equal(t, uint(0), s.T_, "wrong value")
 }
 
 func TestParseFieldSelectorSimple(t *testing.T) {

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -148,7 +148,7 @@ func TestParseUnitBadPractice(t *testing.T) {
 	TestTable := []*strUnit{
 		{T: "10"}, {T: " 10"}, {T: "10 "},
 		{T: "MB"}, {T: " MB"}, {T: " MB"},
-		{T: " 1 B"}, {T: "something"},
+		{T: " 1 B"}, {T: "something"}, {T: ""},
 	}
 	for i := range TestTable {
 		err := Parse(TestTable[i], nil)

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -153,52 +153,72 @@ func TestParseUnitInvalid(t *testing.T) {
 	}{
 		{
 			strUnit:       &strUnit{T: "10"},
-			ExpectedError: errors.New("unexpected alias "),
+			ExpectedError: errors.New("invalid data format, the string must contain 2 parts separated by a space"),
 			ExpectedValue: 0,
 		},
 		{
 			strUnit:       &strUnit{T: " 10"},
-			ExpectedError: errors.New("could not parse number, err: strconv.Atoi: parsing \"\": invalid syntax"),
+			ExpectedError: errors.New(`can't parse uint: "" is not a number`),
 			ExpectedValue: 0,
 		},
 		{
 			strUnit:       &strUnit{T: "10 "},
-			ExpectedError: errors.New("unexpected alias "),
+			ExpectedError: errors.New(`unexpected alias ""`),
 			ExpectedValue: 0,
 		},
 		{
 			strUnit:       &strUnit{T: " 1 MB"},
-			ExpectedError: errors.New("could not parse number, err: strconv.Atoi: parsing \"\": invalid syntax"),
+			ExpectedError: errors.New("invalid data format, the string must contain 2 parts separated by a space"),
 			ExpectedValue: 0,
 		},
 		{
 			strUnit:       &strUnit{T: " MB"},
-			ExpectedError: errors.New("could not parse number, err: strconv.Atoi: parsing \"\": invalid syntax"),
+			ExpectedError: errors.New(`can't parse uint: "" is not a number`),
 			ExpectedValue: 0,
 		},
 		{
 			strUnit:       &strUnit{T: "MB "},
-			ExpectedError: errors.New("could not parse number, err: strconv.Atoi: parsing \"MB\": invalid syntax"),
+			ExpectedError: errors.New(`can't parse uint: "MB" is not a number`),
 			ExpectedValue: 0,
 		},
 		{
 			strUnit:       &strUnit{T: "10 "},
-			ExpectedError: errors.New("unexpected alias "),
+			ExpectedError: errors.New(`unexpected alias ""`),
 			ExpectedValue: 0,
 		},
 		{
 			strUnit:       &strUnit{T: "something"},
-			ExpectedError: errors.New("could not parse number, err: strconv.Atoi: parsing \"something\": invalid syntax"),
+			ExpectedError: errors.New("invalid data format, the string must contain 2 parts separated by a space"),
+			ExpectedValue: 0,
+		},
+		{
+			strUnit:       &strUnit{T: "some thing"},
+			ExpectedError: errors.New(`can't parse uint: "some" is not a number`),
 			ExpectedValue: 0,
 		},
 		{
 			strUnit:       &strUnit{T: ""},
-			ExpectedError: errors.New("could not parse number, err: strconv.Atoi: parsing \"\": invalid syntax"),
+			ExpectedError: errors.New("invalid data format, the string must contain 2 parts separated by a space"),
 			ExpectedValue: 0,
 		},
 		{
 			strUnit:       &strUnit{T: "999999999999999999999 B"},
-			ExpectedError: errors.New("could not parse number, err: strconv.Atoi: parsing \"999999999999999999999\": value out of range"),
+			ExpectedError: errors.New(`can't parse uint: "999999999999999999999" is not a number`),
+			ExpectedValue: 0,
+		},
+		{
+			strUnit:       &strUnit{T: "1  B"},
+			ExpectedError: errors.New("invalid data format, the string must contain 2 parts separated by a space"),
+			ExpectedValue: 0,
+		},
+		{
+			strUnit:       &strUnit{T: "1 B "},
+			ExpectedError: errors.New("invalid data format, the string must contain 2 parts separated by a space"),
+			ExpectedValue: 0,
+		},
+		{
+			strUnit:       &strUnit{T: "-1 PB"},
+			ExpectedError: errors.New("value must be positive"),
 			ExpectedValue: 0,
 		},
 		// TODO: handle uint overflow situation
@@ -210,7 +230,7 @@ func TestParseUnitInvalid(t *testing.T) {
 	}
 	for i := range TestList {
 		err := Parse(TestList[i].strUnit, nil)
-		assert.Equal(t, err, TestList[i].ExpectedError, "wrong error")
+		assert.Equal(t, TestList[i].ExpectedError, err, "wrong error")
 		assert.Equal(t, uint(0), TestList[i].strUnit.T_, "wrong value")
 	}
 }
@@ -238,18 +258,6 @@ func TestParseUnitValid(t *testing.T) {
 		},
 		{
 			strUnit:       &strUnit{T: "1 B"},
-			ExpectedValue: 1,
-		},
-		{
-			strUnit:       &strUnit{T: "1  B"},
-			ExpectedValue: 1,
-		},
-		{
-			strUnit:       &strUnit{T: "1 B "},
-			ExpectedValue: 1,
-		},
-		{
-			strUnit:       &strUnit{T: "1  B "},
 			ExpectedValue: 1,
 		},
 	}

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -148,20 +148,36 @@ func TestParseUnitNumber(t *testing.T) {
 	s := &strUnit{T: "10"}
 	err := Parse(s, nil)
 
-	assert.Nil(t, err, "shouldn't be an error")
-	assert.Equal(t, uint(10), s.T_, "wrong value")
+	assert.Errorf(t, err, "shouldn't be an error")
+	assert.Equal(t, uint(0), s.T_, "wrong value")
 }
 
 func TestParseUnitNumberWithSpace(t *testing.T) {
 	s := &strUnit{T: "10 "}
 	err := Parse(s, nil)
 
-	assert.Nil(t, err, "shouldn't be an error")
-	assert.Equal(t, uint(10), s.T_, "wrong value")
+	assert.Errorf(t, err, "shouldn't be an error")
+	assert.Equal(t, uint(0), s.T_, "wrong value")
 }
 
 func TestParseUnitNumberWithAlias(t *testing.T) {
 	s := &strUnit{T: "10 MB"}
+	err := Parse(s, nil)
+
+	assert.Nil(t, err, "shouldn't be an error")
+	assert.Equal(t, uint(10000000), s.T_, "wrong value")
+}
+
+func TestParseUnitSpacePlusNumberWithAlias(t *testing.T) {
+	s := &strUnit{T: " 10 MB"}
+	err := Parse(s, nil)
+
+	assert.Error(t, err, "shouldn't be an error")
+	assert.Equal(t, uint(0), s.T_, "wrong value")
+}
+
+func TestParseUnitNumberWithAliasPlusSpace(t *testing.T) {
+	s := &strUnit{T: "10 MB "}
 	err := Parse(s, nil)
 
 	assert.Nil(t, err, "shouldn't be an error")

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -48,6 +48,11 @@ type strExpression struct {
 	T_ int
 }
 
+type strUnit struct {
+	T  string `parse:"unit"`
+	T_ uint
+}
+
 type hierarchyChild struct {
 	T string `required:"true"`
 }
@@ -137,6 +142,14 @@ func TestParseExpressionConst(t *testing.T) {
 
 	assert.Nil(t, err, "shouldn't be an error")
 	assert.Equal(t, 10, s.T_, "wrong value")
+}
+
+func TestParseUnit(t *testing.T) {
+	s := &strUnit{T: "10 MB"}
+	err := Parse(s, nil)
+
+	assert.Nil(t, err, "shouldn't be an error")
+	assert.Equal(t, uint(10000000), s.T_, "wrong value")
 }
 
 func TestParseFieldSelectorSimple(t *testing.T) {

--- a/cfg/data_unit.go
+++ b/cfg/data_unit.go
@@ -18,10 +18,10 @@ const (
 	PiB = 1024 * TiB
 )
 
-// UnitAlias is map to add alias.
+// DataUnitAliases is map to add alias.
 // Alias must not contain space
 // Only lowercase letters should be used in the map, but aliases are case-insensitive
-var UnitAlias = map[string]int{
+var DataUnitAliases = map[string]int{
 	"kb": KB, "kib": KiB,
 	"mb": MB, "mib": MiB,
 	"gb": GB, "gib": GiB,

--- a/cfg/unit.go
+++ b/cfg/unit.go
@@ -1,0 +1,30 @@
+package cfg
+
+const (
+	// Decimal
+
+	KB = 1000
+	MB = 1000 * KB
+	GB = 1000 * MB
+	TB = 1000 * GB
+	PB = 1000 * TB
+
+	// Binary
+
+	KiB = 1024
+	MiB = 1024 * KiB
+	GiB = 1024 * MiB
+	TiB = 1024 * GiB
+	PiB = 1024 * TiB
+)
+
+// Use map to add alias.
+// Alias must not contain spaces
+
+var UnitAlias = map[string]int{
+	"KB": KB, "KiB": KiB,
+	"MB": MB, "MiB": MiB,
+	"GB": GB, "GiB": GiB,
+	"TB": TB, "TiB": TiB,
+	"PB": PB, "PiB": PiB,
+}

--- a/cfg/unit.go
+++ b/cfg/unit.go
@@ -22,6 +22,7 @@ const (
 // Alias must not contain spaces
 
 var UnitAlias = map[string]int{
+	"":   1,
 	"KB": KB, "KiB": KiB,
 	"MB": MB, "MiB": MiB,
 	"GB": GB, "GiB": GiB,

--- a/cfg/unit.go
+++ b/cfg/unit.go
@@ -1,9 +1,10 @@
 package cfg
 
 const (
+	B = 1
 	// Decimal
 
-	KB = 1000
+	KB = 1000 * B
 	MB = 1000 * KB
 	GB = 1000 * MB
 	TB = 1000 * GB
@@ -11,7 +12,7 @@ const (
 
 	// Binary
 
-	KiB = 1024
+	KiB = 1024 * B
 	MiB = 1024 * KiB
 	GiB = 1024 * MiB
 	TiB = 1024 * GiB
@@ -22,10 +23,10 @@ const (
 // Alias must not contain spaces
 
 var UnitAlias = map[string]int{
-	"":   1,
 	"KB": KB, "KiB": KiB,
 	"MB": MB, "MiB": MiB,
 	"GB": GB, "GiB": GiB,
 	"TB": TB, "TiB": TiB,
 	"PB": PB, "PiB": PiB,
+	"B": B,
 }

--- a/cfg/unit.go
+++ b/cfg/unit.go
@@ -2,16 +2,15 @@ package cfg
 
 const (
 	B = 1
-	// Decimal
 
+	// KB ,MB ,GB ,TB ,PB are Decimal
 	KB = 1000 * B
 	MB = 1000 * KB
 	GB = 1000 * MB
 	TB = 1000 * GB
 	PB = 1000 * TB
 
-	// Binary
-
+	// KiB ,MiB ,GiB ,TiB ,PiB are Binary
 	KiB = 1024 * B
 	MiB = 1024 * KiB
 	GiB = 1024 * MiB
@@ -19,14 +18,14 @@ const (
 	PiB = 1024 * TiB
 )
 
-// Use map to add alias.
-// Alias must not contain spaces
-
+// UnitAlias is map to add alias.
+// Alias must not contain space
+// Only lowercase letters should be used in the map, but aliases are case-insensitive
 var UnitAlias = map[string]int{
-	"KB": KB, "KiB": KiB,
-	"MB": MB, "MiB": MiB,
-	"GB": GB, "GiB": GiB,
-	"TB": TB, "TiB": TiB,
-	"PB": PB, "PiB": PiB,
-	"B": B,
+	"kb": KB, "kib": KiB,
+	"mb": MB, "mib": MiB,
+	"gb": GB, "gib": GiB,
+	"tb": TB, "tib": TiB,
+	"pb": PB, "pib": PiB,
+	"b": B,
 }


### PR DESCRIPTION
# Description

Add a new configuration handler type cfg.Unit . It allows you to use units of measurement KB KiB, MB, MiB and others. Also cfg.Unit must support adding aliases.
Fixes #138 