### PR TITLE
Add metrics for input file plugin possible offset corruption

### DIFF
--- a/plugin/input/file/file.go
+++ b/plugin/input/file/file.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ozontech/file.d/cfg"
 	"github.com/ozontech/file.d/fd"
 	"github.com/ozontech/file.d/pipeline"
+	"github.com/ozontech/file.d/stats"
 	"go.uber.org/zap"
 )
 
@@ -42,6 +43,11 @@ pipelines:
         persistence_mode: async
 ```
 }*/
+
+const (
+	subsystemName                   = "input_file"
+	possibleOffsetCorruptionCounter = "possible_offset_corruptions_total"
+)
 
 type Plugin struct {
 	config *Config
@@ -183,6 +189,8 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.InputPluginPa
 	p.params = params
 	p.config = config.(*Config)
 
+	p.registerPluginMetrics()
+
 	p.config.OffsetsFileTmp = p.config.OffsetsFile + ".atomic"
 
 	p.jobProvider = NewJobProvider(p.config, p.params.Controller, p.logger)
@@ -191,6 +199,14 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.InputPluginPa
 
 	p.startWorkers()
 	p.jobProvider.start()
+}
+
+func (p *Plugin) registerPluginMetrics() {
+	stats.RegisterCounter(&stats.MetricDesc{
+		Subsystem: subsystemName,
+		Name:      possibleOffsetCorruptionCounter,
+		Help:      "Total number of possible offset corruptions",
+	})
 }
 
 func (p *Plugin) startWorkers() {

--- a/plugin/input/file/provider.go
+++ b/plugin/input/file/provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ozontech/file.d/logger"
 	"github.com/ozontech/file.d/longpanic"
 	"github.com/ozontech/file.d/pipeline"
+	"github.com/ozontech/file.d/stats"
 	"github.com/rjeczalik/notify"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
@@ -193,6 +194,7 @@ func (jp *jobProvider) commit(event *pipeline.Event) {
 	}
 
 	if value == 0 && event.Offset >= 16*1024*1024 {
+		stats.GetCounter(subsystemName, possibleOffsetCorruptionCounter).Inc()
 		jp.logger.Errorf("it maybe an offset corruption: committing=%d, current=%d, event id=%d, source=%d:%s", event.Offset, value, event.SeqID, event.SourceID, event.SourceName)
 	}
 


### PR DESCRIPTION
Closes #148 . Add metrics for input file plugin possible offset corruption events.