### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/cmd/file.d_test.go
+++ b/cmd/file.d_test.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -87,8 +86,8 @@ func TestEndToEnd(t *testing.T) {
 	k8s2.MetaWaitTimeout = time.Millisecond
 	k8s2.MaintenanceInterval = time.Millisecond * 100
 
-	filesDir, _ := ioutil.TempDir("", "file.d")
-	offsetsDir, _ := ioutil.TempDir("", "file.d")
+	filesDir := t.TempDir()
+	offsetsDir := t.TempDir()
 
 	config := cfg.NewConfigFromFile(configFilename)
 	input := config.Pipelines["test"].Raw.Get("input")

--- a/offset/offset_test.go
+++ b/offset/offset_test.go
@@ -3,7 +3,6 @@ package offset
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -18,12 +17,6 @@ type testOffset struct {
 func (o *testOffset) set(name string, value int) {
 	o.Name = name
 	o.Value = value
-}
-
-func getTmpPath(t *testing.T, file string) string {
-	res, err := os.MkdirTemp("", "file.d")
-	assert.NoError(t, err)
-	return filepath.Join(res, file)
 }
 
 func TestYAML(t *testing.T) {
@@ -44,7 +37,7 @@ func TestYAML(t *testing.T) {
 }
 
 func TestSaveLoad(t *testing.T) {
-	path := getTmpPath(t, "offset.yaml")
+	path := filepath.Join(t.TempDir(), "offset.yaml")
 	offset := testOffset{}
 	offset.set("some_name", 123)
 
@@ -59,7 +52,7 @@ func TestSaveLoad(t *testing.T) {
 }
 
 func TestAppendFile(t *testing.T) {
-	path := getTmpPath(t, "offset.yaml")
+	path := filepath.Join(t.TempDir(), "offset.yaml")
 	for i := 1; i < 5; i++ {
 		offset := testOffset{}
 		offset.set(fmt.Sprintf("iter_%d", i), i)
@@ -77,7 +70,7 @@ func TestAppendFile(t *testing.T) {
 
 // check, that no errors will happen
 func TestNoFile(t *testing.T) {
-	path := getTmpPath(t, "offset.yaml")
+	path := filepath.Join(t.TempDir(), "offset.yaml")
 
 	loaded := testOffset{}
 	err := LoadYAML(path, &loaded)

--- a/plugin/input/file/watcher_test.go
+++ b/plugin/input/file/watcher_test.go
@@ -27,8 +27,7 @@ func TestWatcher(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			path, err := os.MkdirTemp("/tmp", "watcher_test")
-			require.NoError(t, err)
+			path := t.TempDir()
 			shouldCreate := atomic.Int64{}
 			notifyFn := func(_ notify.Event, _ string, _ os.FileInfo) {
 				shouldCreate.Inc()

--- a/plugin/input/journalctl/journalctl_test.go
+++ b/plugin/input/journalctl/journalctl_test.go
@@ -3,7 +3,6 @@
 package journalctl
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -14,12 +13,6 @@ import (
 	"github.com/ozontech/file.d/test"
 	"github.com/stretchr/testify/assert"
 )
-
-func getTmpPath(t *testing.T, file string) string {
-	res, err := os.MkdirTemp("", "file.d")
-	assert.NoError(t, err)
-	return filepath.Join(res, file)
-}
 
 func setInput(p *pipeline.Pipeline, config *Config, t *testing.T) {
 	p.SetInput(&pipeline.InputPluginInfo{
@@ -50,7 +43,7 @@ func setOutput(p *pipeline.Pipeline, out func(event *pipeline.Event)) {
 
 func TestPipeline(t *testing.T) {
 	p := test.NewPipeline(nil, "passive")
-	config := &Config{OffsetsFile: getTmpPath(t, "offset.yaml"), MaxLines: 10}
+	config := &Config{OffsetsFile: filepath.Join(t.TempDir(), "offset.yaml"), MaxLines: 10}
 	err := cfg.Parse(config, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"-f", "-a"}, config.JournalArgs)
@@ -71,7 +64,7 @@ func TestPipeline(t *testing.T) {
 }
 
 func TestOffsets(t *testing.T) {
-	offsetPath := getTmpPath(t, "offset.yaml")
+	offsetPath := filepath.Join(t.TempDir(), "offset.yaml")
 
 	config := &Config{OffsetsFile: offsetPath, MaxLines: 5}
 	err := cfg.Parse(config, nil)


### PR DESCRIPTION
# Description

A testing cleanup. 

This pull request replaces `ioutil.TempDir` and `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	require.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```