### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -2,7 +2,6 @@ package cfg
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"regexp"
@@ -53,7 +52,7 @@ func NewConfig() *Config {
 
 func NewConfigFromFile(path string) *Config {
 	logger.Infof("reading config %q", path)
-	yamlContents, err := ioutil.ReadFile(path)
+	yamlContents, err := os.ReadFile(path)
 	if err != nil {
 		logger.Fatalf("can't read config file %q: %s", path, err)
 	}

--- a/plugin/input/file/file_test.go
+++ b/plugin/input/file/file_test.go
@@ -2,7 +2,6 @@ package file
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -271,7 +270,7 @@ func addLines(file string, from int, to int) int {
 }
 
 func getContent(file string) string {
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	if err != nil {
 		panic(err)
 	}
@@ -280,7 +279,7 @@ func getContent(file string) string {
 }
 
 func getContentBytes(file string) []byte {
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	if err != nil {
 		panic(err)
 	}
@@ -1138,11 +1137,7 @@ func BenchmarkLightJsonReadPar(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		p, _, output := test.NewPipelineMock(nil, "passive", "perf")
 
-		f, err := os.MkdirTemp("", "off")
-		if err != nil {
-			panic(err.Error())
-		}
-		offsetsDir = f
+		offsetsDir = b.TempDir()
 		p.SetInput(getInputInfo())
 
 		wg := &sync.WaitGroup{}

--- a/plugin/input/file/offset.go
+++ b/plugin/input/file/offset.go
@@ -2,7 +2,6 @@ package file
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"strconv"
@@ -59,7 +58,7 @@ func (o *offsetDB) load() (fpOffsets, error) {
 		logger.Fatalf("can't load offsets, file %s is dir")
 	}
 
-	content, err := ioutil.ReadFile(o.curOffsetsFile)
+	content, err := os.ReadFile(o.curOffsetsFile)
 	if err != nil {
 		logger.Panicf("can't read offset file: %s", err.Error())
 	}

--- a/plugin/input/file/watcher.go
+++ b/plugin/input/file/watcher.go
@@ -1,7 +1,6 @@
 package file
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -81,7 +80,7 @@ func (w *watcher) stop() {
 }
 
 func (w *watcher) tryAddPath(path string) {
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return
 	}

--- a/plugin/input/http/http_test.go
+++ b/plugin/input/http/http_test.go
@@ -3,9 +3,9 @@ package http
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"runtime"
 	"strings"
 	"sync"
@@ -332,7 +332,7 @@ func BenchmarkHttpInputJson(b *testing.B) {
 	const NumWorkers = 128
 	const DocumentCount = 128 * 128 * 8
 
-	json, err := ioutil.ReadFile("../../../testdata/json/light.json")
+	json, err := os.ReadFile("../../../testdata/json/light.json")
 	if err != nil {
 		panic(err)
 	}
@@ -353,7 +353,7 @@ func BenchmarkHttpInputJson(b *testing.B) {
 			if err != nil {
 				panic(err)
 			}
-			_, _ = io.Copy(ioutil.Discard, resp.Body) // https://github.com/google/go-github/pull/317
+			_, _ = io.Copy(io.Discard, resp.Body) // https://github.com/google/go-github/pull/317
 			_ = resp.Body.Close()
 			if resp.StatusCode != http.StatusOK {
 				panic(resp.Status)

--- a/plugin/input/k8s/gatherer.go
+++ b/plugin/input/k8s/gatherer.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -423,7 +422,7 @@ func parseLogFilename(fullFilename string) (namespace, podName, containerName, c
 }
 
 func getNamespace() string {
-	data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
 		return ""
 	}

--- a/plugin/output/s3/s3.go
+++ b/plugin/output/s3/s3.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -369,7 +368,7 @@ func (p *Plugin) getDynamicDirsArtifacts(targetDirs map[string]string) map[strin
 	dynamicDirs := make(map[string]string)
 
 	dynamicDirsPath := filepath.Join(targetDirs[p.config.DefaultBucket], DynamicBucketDir)
-	dynamicDir, err := ioutil.ReadDir(dynamicDirsPath)
+	dynamicDir, err := os.ReadDir(dynamicDirsPath)
 	// If no such dir, no dynamic dirs existed.
 	if err != nil {
 		return nil

--- a/plugin/output/s3/s3_internals.go
+++ b/plugin/output/s3/s3_internals.go
@@ -3,7 +3,7 @@ package s3
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/minio/minio-go"
@@ -72,7 +72,7 @@ func (p *Plugin) getFileNames(outPlugCount int) map[string]string {
 // Try to create buckets from dirs lying in dynamic_dirs route
 func (p *Plugin) createPlugsFromDynamicBucketArtifacts(targetDirs map[string]string) {
 	dynamicDirsPath := filepath.Join(targetDirs[p.config.DefaultBucket], DynamicBucketDir)
-	dynamicDir, err := ioutil.ReadDir(dynamicDirsPath)
+	dynamicDir, err := os.ReadDir(dynamicDirsPath)
 	if err != nil {
 		p.logger.Infof("%s doesn't exist, won't restore dynamic s3 buckets", err.Error())
 		return

--- a/plugin/output/splunk/splunk_test.go
+++ b/plugin/output/splunk/splunk_test.go
@@ -1,7 +1,7 @@
 package splunk
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -35,7 +35,7 @@ func TestSplunk(t *testing.T) {
 
 			var response []byte
 			testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-				response, err = ioutil.ReadAll(req.Body)
+				response, err = io.ReadAll(req.Body)
 				if err != nil {
 					t.Fatal(err)
 				}


### PR DESCRIPTION
# Description

Recently we have upgraded to Go 1.19 in #226. The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

This PR also fixes the `ioutilDeprecated (gocritic)` lint errors.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir` (returns a slice of `os.DirEntry` rather than a slice of `fs.FileInfo`, this may improve performance in some cases as `os.ReadDir` is more efficient [\[1\]])
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`

[\[1\]]: https://pkg.go.dev/io/ioutil#ReadDir