### PR TITLE
Regex performance in mask plugin (ignored fields && common match regex)

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -319,6 +319,8 @@ pipelines:
     actions:
     - type: mask
       metric_subsystem_name: "some_name"
+      ignore_fields:
+      - trace_id
       masks:
       - mask:
         re: "\b(\d{1,4})\D?(\d{1,4})\D?(\d{1,4})\D?(\d{1,4})\b"

--- a/plugin/action/README.md
+++ b/plugin/action/README.md
@@ -154,6 +154,8 @@ pipelines:
     actions:
     - type: mask
       metric_subsystem_name: "some_name"
+      ignore_fields:
+      - trace_id
       masks:
       - mask:
         re: "\b(\d{1,4})\D?(\d{1,4})\D?(\d{1,4})\D?(\d{1,4})\b"

--- a/plugin/action/mask/README.md
+++ b/plugin/action/mask/README.md
@@ -27,7 +27,7 @@ List of masks.
 
 **`skip_mismatched`** *`bool`* *`default=false`* 
 
-**Experimental feature** for best perfomance. Skips events with mismatched masks.
+**Experimental feature** for best performance. Skips events with mismatched masks.
 
 <br>
 
@@ -44,7 +44,7 @@ If any mask has been applied then `mask_applied_field` will be set to `mask_appl
 
 **`ignore_fields`** *`[]string`* 
 
-List of the ignored event fields.
+List of the ignored event fields (including nested fields).
 
 <br>
 

--- a/plugin/action/mask/README.md
+++ b/plugin/action/mask/README.md
@@ -10,6 +10,8 @@ pipelines:
     actions:
     - type: mask
       metric_subsystem_name: "some_name"
+      ignore_fields:
+      - trace_id
       masks:
       - mask:
         re: "\b(\d{1,4})\D?(\d{1,4})\D?(\d{1,4})\D?(\d{1,4})\b"

--- a/plugin/action/mask/README.md
+++ b/plugin/action/mask/README.md
@@ -36,6 +36,12 @@ If any mask has been applied then `mask_applied_field` will be set to `mask_appl
 
 <br>
 
+**`ignore_fields`** *`[]string`* 
+
+List of the ignored event fields.
+
+<br>
+
 **`applied_metric_name`** *`string`* *`default=mask_applied_total`* 
 
 The metric name of the regular expressions applied.

--- a/plugin/action/mask/README.md
+++ b/plugin/action/mask/README.md
@@ -25,6 +25,12 @@ List of masks.
 
 <br>
 
+**`skip_mismatched`** *`bool`* *`default=false`* 
+
+**Experimental feature** for best perfomance. Skips events with mismatched masks.
+
+<br>
+
 **`mask_applied_field`** *`string`* 
 
 If any mask has been applied then `mask_applied_field` will be set to `mask_applied_value` in the event.

--- a/plugin/action/mask/mask_test.go
+++ b/plugin/action/mask/mask_test.go
@@ -176,6 +176,7 @@ func TestMaskAddExtraField(t *testing.T) {
 	config := test.NewConfig(&Config{
 		MaskAppliedField: key,
 		MaskAppliedValue: val,
+		SkipMismatched:   true,
 		Masks: []Mask{
 			{Re: kDefaultCardRegExp, Groups: []int{1, 2, 3, 4}},
 		},
@@ -481,6 +482,7 @@ func TestPlugin(t *testing.T) {
 	}
 
 	config := test.NewConfig(&Config{
+		SkipMismatched: true,
 		Masks: []Mask{
 			{
 				Re:     `a(x*)b`,
@@ -685,6 +687,7 @@ func TestPluginWithComplexMasks(t *testing.T) {
 	for _, s := range suits {
 		t.Run(s.name, func(t *testing.T) {
 			config := test.NewConfig(&Config{
+				SkipMismatched:      true,
 				Masks:               s.masks,
 				AppliedMetricName:   s.metricName,
 				AppliedMetricLabels: s.metricLabels,

--- a/plugin/action/mask/mask_test.go
+++ b/plugin/action/mask/mask_test.go
@@ -318,7 +318,7 @@ func TestGetValueNodeList(t *testing.T) {
 	suits := []struct {
 		name          string
 		input         string
-		ignoredFields map[string]interface{}
+		ignoredFields map[string]struct{}
 		expected      []string
 		comment       string
 	}{
@@ -337,8 +337,8 @@ func TestGetValueNodeList(t *testing.T) {
 		{
 			name:  "test with ignored field",
 			input: `{"name1":"value1", "ignored_field":"value2"}`,
-			ignoredFields: map[string]interface{}{
-				"ignored_field": nil,
+			ignoredFields: map[string]struct{}{
+				"ignored_field": {},
 			},
 			expected: []string{"value1"},
 			comment:  "skip ignored_field",
@@ -351,8 +351,8 @@ func TestGetValueNodeList(t *testing.T) {
 					"ignored_field":"value2"
 				}
 			}`,
-			ignoredFields: map[string]interface{}{
-				"ignored_field": nil,
+			ignoredFields: map[string]struct{}{
+				"ignored_field": {},
 			},
 			expected: []string{"value1"},
 			comment:  "skip nested ignored_field",


### PR DESCRIPTION
# Description

Here are two improvements for mask plugin:

- ignored fields in mask plugin
- compile common match regex (regex_1|regex_2|regex_3) and skip mismatched event before process