### PR TITLE
file input plugin: many include patterns and patterns for exclude

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137
 	github.com/alicebob/miniredis/v2 v2.30.5
 	github.com/bitly/go-simplejson v0.5.1
+	github.com/bmatcuk/doublestar/v4 v4.0.2
 	github.com/euank/go-kmsg-parser v2.0.0+incompatible
 	github.com/go-redis/redis v6.15.9+incompatible
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bitly/go-simplejson v0.5.1 h1:xgwPbetQScXt1gh9BmoJ6j9JMr3TElvuIyjR8pgdoow=
 github.com/bitly/go-simplejson v0.5.1/go.mod h1:YOPVLzCfwK14b4Sff3oP1AmGhI9T9Vsg84etUnlyp+Q=
+github.com/bmatcuk/doublestar/v4 v4.0.2 h1:X0krlUVAVmtr2cRoTqR8aDMrDqnB36ht8wpWTiQ3jsA=
+github.com/bmatcuk/doublestar/v4 v4.0.2/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -37,8 +37,12 @@ pipelines:
     input:
         type: file
         watching_dir: /var/lib/docker/containers
+        paths:
+          include:
+            - '**\/*-json.log' # remove \
+          exclude:
+            - ef933707fe551f512d0b240558fdd01771f7897cccab75eb4fab0e575393ab79
         offsets_file: /data/offsets.yaml
-        filename_pattern: "*-json.log"
         persistence_mode: async
 ```
 

--- a/plugin/input/README.md
+++ b/plugin/input/README.md
@@ -36,8 +36,12 @@ pipelines:
     input:
         type: file
         watching_dir: /var/lib/docker/containers
+        paths:
+          include:
+            - '**\/*-json.log' # remove \
+          exclude:
+            - ef933707fe551f512d0b240558fdd01771f7897cccab75eb4fab0e575393ab79
         offsets_file: /data/offsets.yaml
-        filename_pattern: "*-json.log"
         persistence_mode: async
 ```
 

--- a/plugin/input/file/README.md
+++ b/plugin/input/file/README.md
@@ -26,18 +26,35 @@ pipelines:
     input:
         type: file
         watching_dir: /var/lib/docker/containers
+        paths:
+          include:
+            - '**\/*-json.log' # remove \
+          exclude:
+            - ef933707fe551f512d0b240558fdd01771f7897cccab75eb4fab0e575393ab79
         offsets_file: /data/offsets.yaml
-        filename_pattern: "*-json.log"
         persistence_mode: async
 ```
 
 ### Config params
 **`watching_dir`** *`string`* *`required`* 
 
+List of included pathes
+*`string`* *`required`* 
+
+List of excluded pathes
+*`string`* *`required`* 
+
 The source directory to watch for files to process. All subdirectories also will be watched. E.g. if files have
 `/var/my-logs/$YEAR/$MONTH/$DAY/$HOST/$FACILITY-$PROGRAM.log` structure, `watching_dir` should be `/var/my-logs`.
 Also the `filename_pattern`/`dir_pattern` is useful to filter needless files/subdirectories. In the case of using two or more
 different directories, it's recommended to setup separate pipelines for each.
+
+<br>
+
+**`paths`** *`Paths`* 
+
+Paths.
+> Check out [func Glob docs](https://golang.org/pkg/path/filepath/#Glob) for details.
 
 <br>
 

--- a/plugin/input/file/file.go
+++ b/plugin/input/file/file.go
@@ -40,8 +40,12 @@ pipelines:
     input:
         type: file
         watching_dir: /var/lib/docker/containers
+        paths:
+          include:
+            - '**\/*-json.log' # remove \
+          exclude:
+            - ef933707fe551f512d0b240558fdd01771f7897cccab75eb4fab0e575393ab79
         offsets_file: /data/offsets.yaml
-        filename_pattern: "*-json.log"
         persistence_mode: async
 ```
 }*/
@@ -78,6 +82,18 @@ const (
 	offsetsOpReset                     // * `reset` – resets an offset to the beginning of the file
 )
 
+type Paths struct {
+	// > @3@4@5@6
+	// >
+	// > List of included pathes
+	Include []string `json:"include"`
+
+	// > @3@4@5@6
+	// >
+	// > List of excluded pathes
+	Exclude []string `json:"exclude"`
+}
+
 type Config struct {
 	// ! config-params
 	// ^ config-params
@@ -89,6 +105,12 @@ type Config struct {
 	// > Also the `filename_pattern`/`dir_pattern` is useful to filter needless files/subdirectories. In the case of using two or more
 	// > different directories, it's recommended to setup separate pipelines for each.
 	WatchingDir string `json:"watching_dir" required:"true"` // *
+
+	// > @3@4@5@6
+	// >
+	// > Paths.
+	// > > Check out [func Glob docs](https://golang.org/pkg/path/filepath/#Glob) for details.
+	Paths Paths `json:"paths"` // *
 
 	// > @3@4@5@6
 	// >

--- a/plugin/input/file/provider.go
+++ b/plugin/input/file/provider.go
@@ -125,10 +125,23 @@ func NewJobProvider(config *Config, possibleOffsetCorruptionMetric, errorOpenFil
 		errorOpenFileMetric:            errorOpenFileMetric,
 	}
 
+	if len(config.Paths.Include) == 0 {
+		if config.DirPattern == "*" {
+			config.Paths.Include = append(
+				config.Paths.Include,
+				filepath.Join("**", config.FilenamePattern),
+			)
+		} else {
+			config.Paths.Include = append(
+				config.Paths.Include,
+				filepath.Join(config.DirPattern, config.FilenamePattern),
+			)
+		}
+	}
+
 	jp.watcher = NewWatcher(
 		config.WatchingDir,
-		config.FilenamePattern,
-		config.DirPattern,
+		config.Paths,
 		jp.processNotification,
 		config.ShouldWatchChanges,
 		sugLogger,

--- a/plugin/input/file/provider_test.go
+++ b/plugin/input/file/provider_test.go
@@ -1,0 +1,91 @@
+package file
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/ozontech/file.d/metric"
+	"github.com/ozontech/file.d/test"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestProvierWatcherPaths(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         *Config
+		expectedPathes Paths
+	}{
+		{
+			name: "default config",
+			config: &Config{
+				WatchingDir: "/var/log/",
+				OffsetsFile: "offset.json",
+			},
+			expectedPathes: Paths{
+				Include: []string{"**/*"},
+			},
+		},
+		{
+			name: "filename pattern config",
+			config: &Config{
+				WatchingDir:     "/var/log/",
+				FilenamePattern: "error.log",
+				OffsetsFile:     "offset.json",
+			},
+			expectedPathes: Paths{
+				Include: []string{"**/error.log"},
+			},
+		},
+		{
+			name: "filename and dir pattern config",
+			config: &Config{
+				WatchingDir:     "/var/log/",
+				FilenamePattern: "error.log",
+				DirPattern:      "nginx-ingress-*",
+				OffsetsFile:     "offset.json",
+			},
+			expectedPathes: Paths{
+				Include: []string{"nginx-ingress-*/error.log"},
+			},
+		},
+		{
+			name: "dir pattern config",
+			config: &Config{
+				WatchingDir: "/var/log/",
+				DirPattern:  "nginx-ingress-*",
+				OffsetsFile: "offset.json",
+			},
+			expectedPathes: Paths{
+				Include: []string{"nginx-ingress-*/*"},
+			},
+		},
+		{
+			name: "ignore filename and dir pattern",
+			config: &Config{
+				WatchingDir:     "/var/log/",
+				FilenamePattern: "error.log",
+				DirPattern:      "nginx-ingress-*",
+				OffsetsFile:     "offset.json",
+				Paths: Paths{
+					Include: []string{"access.log"},
+				},
+			},
+			expectedPathes: Paths{
+				Include: []string{"access.log"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctl := metric.New("test", prometheus.NewRegistry())
+			testMetric := ctl.RegisterCounter("worker", "help_test")
+			config := tt.config
+			test.NewConfig(config, map[string]int{"gomaxprocs": runtime.GOMAXPROCS(0)})
+			jp := NewJobProvider(config, testMetric, testMetric, &zap.SugaredLogger{})
+
+			assert.Equal(t, tt.expectedPathes, jp.watcher.paths)
+		})
+	}
+}

--- a/plugin/input/file/watcher.go
+++ b/plugin/input/file/watcher.go
@@ -4,14 +4,14 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/rjeczalik/notify"
 	"go.uber.org/zap"
 )
 
 type watcher struct {
-	path              string   // dir in which watch for files
-	filenamePattern   string   // files which match this pattern will be watched
-	dirPattern        string   // dirs which match this pattern will be watched
+	dir               string // dir in which watch for files
+	paths             Paths
 	notifyFn          notifyFn // function to receive notifications
 	watcherCh         chan notify.EventInfo
 	shouldWatchWrites bool
@@ -23,17 +23,15 @@ type notifyFn func(e notify.Event, filename string, stat os.FileInfo)
 // NewWatcher creates a watcher that see file creations in the path
 // and if they match filePattern and dirPattern, pass them to notifyFn.
 func NewWatcher(
-	path string,
-	filenamePattern string,
-	dirPattern string,
+	dir string,
+	paths Paths,
 	notifyFn notifyFn,
 	shouldWatchWrites bool,
 	logger *zap.SugaredLogger,
 ) *watcher {
 	return &watcher{
-		path:              path,
-		filenamePattern:   filenamePattern,
-		dirPattern:        dirPattern,
+		dir:               dir,
+		paths:             paths,
 		notifyFn:          notifyFn,
 		shouldWatchWrites: shouldWatchWrites,
 		logger:            logger,
@@ -41,15 +39,10 @@ func NewWatcher(
 }
 
 func (w *watcher) start() {
-	w.logger.Infof("starting watcher path=%s, pattern=%s", w.path, w.filenamePattern)
-
-	if _, err := filepath.Match(w.filenamePattern, "_"); err != nil {
-		w.logger.Fatalf("wrong file name pattern %q: %s", w.filenamePattern, err.Error())
-	}
-
-	if _, err := filepath.Match(w.dirPattern, "_"); err != nil {
-		w.logger.Fatalf("wrong dir name pattern %q: %s", w.dirPattern, err.Error())
-	}
+	w.logger.Infof(
+		"starting watcher path=%s, pattern_included=%q, pattern_excluded=%q",
+		w.dir, w.paths.Include, w.paths.Exclude,
+	)
 
 	eventsCh := make(chan notify.EventInfo, 256)
 	w.watcherCh = eventsCh
@@ -60,7 +53,7 @@ func (w *watcher) start() {
 	}
 
 	// watch recursively.
-	err := notify.Watch(filepath.Join(w.path, "..."), eventsCh, events...)
+	err := notify.Watch(filepath.Join(w.dir, "..."), eventsCh, events...)
 	if err != nil {
 		w.logger.Warnf("can't create fs watcher: %s", err.Error())
 		return
@@ -68,7 +61,7 @@ func (w *watcher) start() {
 
 	go w.watch()
 
-	w.tryAddPath(w.path)
+	w.tryAddPath(w.dir)
 }
 
 func (w *watcher) stop() {
@@ -107,19 +100,42 @@ func (w *watcher) notify(e notify.Event, path string) {
 		return
 	}
 
+	dirRel, _ := filepath.Abs(w.dir)
+	rel, _ := filepath.Rel(dirRel, filename)
+
+	w.logger.Infof("%s %s", e, path)
+
+	for _, pattern := range w.paths.Exclude {
+		match, err := doublestar.PathMatch(pattern, rel)
+		if err != nil {
+			w.logger.Fatalf("wrong paths exclude pattern %q: %s", pattern, err.Error())
+			return
+		}
+		if match {
+			return
+		}
+	}
+
 	stat, err := os.Lstat(filename)
 	if err != nil {
 		return
 	}
 
-	match, _ := filepath.Match(w.filenamePattern, filepath.Base(filename))
-	if match {
-		w.notifyFn(e, filename, stat)
+	if stat.IsDir() {
+		w.tryAddPath(filename)
+		return
 	}
 
-	match, _ = filepath.Match(w.dirPattern, filepath.Base(filename))
-	if stat.IsDir() && match {
-		w.tryAddPath(filename)
+	for _, pattern := range w.paths.Include {
+		match, err := doublestar.PathMatch(pattern, rel)
+		if err != nil {
+			w.logger.Fatalf("wrong paths include pattern %q: %s", pattern, err.Error())
+			return
+		}
+
+		if match {
+			w.notifyFn(e, filename, stat)
+		}
 	}
 }
 

--- a/plugin/input/file/watcher_test.go
+++ b/plugin/input/file/watcher_test.go
@@ -27,25 +27,39 @@ func TestWatcher(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			path := t.TempDir()
+			dir := t.TempDir()
 			shouldCreate := atomic.Int64{}
 			notifyFn := func(_ notify.Event, _ string, _ os.FileInfo) {
 				shouldCreate.Inc()
 			}
-			w := NewWatcher(path, tt.filenamePattern, tt.dirPattern, notifyFn, false, zap.L().Sugar())
+			w := NewWatcher(
+				dir,
+				Paths{
+					Include: []string{
+						tt.dirPattern,
+						filepath.Join(
+							tt.dirPattern,
+							tt.filenamePattern,
+						),
+					},
+				},
+				notifyFn,
+				false,
+				zap.L().Sugar(),
+			)
 			w.start()
 			defer w.stop()
 
 			// create, write, remove files and ensure events are only passed for creation events.
 
-			f1Name := filepath.Join(path, "watch1.log")
+			f1Name := filepath.Join(dir, "watch1.log")
 
 			f1, err := os.Create(f1Name)
 			require.NoError(t, err)
 			err = f1.Close()
 			require.NoError(t, err)
 
-			f2, err := os.Create(filepath.Join(path, "watch2.log"))
+			f2, err := os.Create(filepath.Join(dir, "watch2.log"))
 			require.NoError(t, err)
 			err = f2.Close()
 			require.NoError(t, err)
@@ -67,6 +81,106 @@ func TestWatcher(t *testing.T) {
 			time.Sleep(10 * time.Millisecond)
 
 			require.Equal(t, int64(2), shouldCreate.Load())
+		})
+	}
+}
+
+func TestWatcherPaths(t *testing.T) {
+	dir := t.TempDir()
+	shouldCreate := atomic.Int64{}
+	notifyFn := func(_ notify.Event, _ string, _ os.FileInfo) {
+		shouldCreate.Inc()
+	}
+	w := NewWatcher(
+		dir,
+		Paths{
+			Include: []string{
+				"nginx-ingress-*/error.log",
+				"log/**/*",
+				"access.log",
+				"**/sub_access.log",
+			},
+			Exclude: []string{
+				"log/payments/**",
+				"nginx-ingress-payments/error.log",
+			},
+		},
+		notifyFn,
+		false,
+		zap.L().Sugar(),
+	)
+	w.start()
+	defer w.stop()
+
+	tests := []struct {
+		name         string
+		filename     string
+		shouldNotify bool
+	}{
+		{
+			filename:     "nginx-ingress-0/error.log",
+			shouldNotify: true,
+		},
+		{
+			filename:     "log/errors.log",
+			shouldNotify: true,
+		},
+		{
+			filename:     "log/0/errors.log",
+			shouldNotify: true,
+		},
+		{
+			filename:     "log/0/0/errors.log",
+			shouldNotify: true,
+		},
+		{
+			filename:     "access.log",
+			shouldNotify: true,
+		},
+		{
+			filename:     "sub_access.log",
+			shouldNotify: true,
+		},
+		{
+			filename:     "access1.log",
+			shouldNotify: false,
+		},
+		{
+			filename:     "nginx/errors.log",
+			shouldNotify: false,
+		},
+		{
+			filename:     "log/payments/errors.log",
+			shouldNotify: false,
+		},
+		{
+			filename:     "log/payments/nginx-ingress-0/errors.log",
+			shouldNotify: false,
+		},
+		{
+			filename:     "nginx-ingress-payments/error.log",
+			shouldNotify: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.filename, func(t *testing.T) {
+			filename := filepath.Join(dir, tt.filename)
+
+			err := os.MkdirAll(filepath.Dir(filename), 0o700)
+			require.NoError(t, err)
+
+			f1, err := os.Create(filename)
+			require.NoError(t, err)
+			err = f1.Close()
+			require.NoError(t, err)
+
+			before := shouldCreate.Load()
+			w.notify(notify.Create, filename)
+			after := shouldCreate.Load()
+
+			isNotified := after-before != 0
+			require.Equal(t, tt.shouldNotify, isNotified)
 		})
 	}
 }


### PR DESCRIPTION
sample config

new format:

```
pipelines:
  welcome:
    input:
      type: file
      persistence_mode: async
      watching_dir: /var/lib/docker/containers
      # filename_pattern: "*-json.log" # old format
      paths:
        include:
          - 'containers/30b28763e40a7649ef73c8afce0b0f4e62546f2a07a174d97e56bd02854facbd/*-json.log'
          - 'containers/65d343a9cc0a9fe6e466a370fcaf8ad6458eb912d19f8e8832e941e2ab7cafa0/*-json.log'
          - 'containers/**/*-json.log'
        exclude:
          - '19aa5027343f4*/*-json.log'
      offsets_file: ./offsets.yaml
      offsets_op: reset
    output:
      type: stdout
```

see also #567