### PR TITLE
file input plugin: define watching_dir from include patterns

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137
 	github.com/alicebob/miniredis/v2 v2.30.5
 	github.com/bitly/go-simplejson v0.5.1
-	github.com/bufbuild/protocompile v0.13.0
 	github.com/bmatcuk/doublestar/v4 v4.0.2
+	github.com/bufbuild/protocompile v0.13.0
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/euank/go-kmsg-parser v2.0.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/bufbuild/protocompile v0.13.0
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/cespare/xxhash/v2 v2.2.0
+	github.com/bmatcuk/doublestar/v4 v4.0.2
 	github.com/euank/go-kmsg-parser v2.0.0+incompatible
 	github.com/go-faster/jx v1.1.0
 	github.com/go-redis/redis v6.15.9+incompatible

--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bmatcuk/doublestar/v4 v4.0.2 // indirect
 	github.com/cenkalti/backoff/v3 v3.0.0 // indirect
 	github.com/cilium/ebpf v0.9.1 // indirect
 	github.com/containerd/cgroups/v3 v3.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,6 @@ require (
 	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/bmatcuk/doublestar/v4 v4.0.2 // indirect
 	github.com/cenkalti/backoff/v3 v3.0.0 // indirect
 	github.com/cilium/ebpf v0.9.1 // indirect
 	github.com/containerd/cgroups/v3 v3.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,9 @@ require (
 	github.com/alicebob/miniredis/v2 v2.30.5
 	github.com/bitly/go-simplejson v0.5.1
 	github.com/bufbuild/protocompile v0.13.0
+	github.com/bmatcuk/doublestar/v4 v4.0.2
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/cespare/xxhash/v2 v2.2.0
-	github.com/bmatcuk/doublestar/v4 v4.0.2
 	github.com/euank/go-kmsg-parser v2.0.0+incompatible
 	github.com/go-faster/jx v1.1.0
 	github.com/go-redis/redis v6.15.9+incompatible

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/bitly/go-simplejson v0.5.1 h1:xgwPbetQScXt1gh9BmoJ6j9JMr3TElvuIyjR8pg
 github.com/bitly/go-simplejson v0.5.1/go.mod h1:YOPVLzCfwK14b4Sff3oP1AmGhI9T9Vsg84etUnlyp+Q=
 github.com/bufbuild/protocompile v0.13.0 h1:6cwUB0Y2tSvmNxsbunwzmIto3xOlJOV7ALALuVOs92M=
 github.com/bufbuild/protocompile v0.13.0/go.mod h1:dr++fGGeMPWHv7jPeT06ZKukm45NJscd7rUxQVzEKRk=
+github.com/bmatcuk/doublestar/v4 v4.0.2 h1:X0krlUVAVmtr2cRoTqR8aDMrDqnB36ht8wpWTiQ3jsA=
+github.com/bmatcuk/doublestar/v4 v4.0.2/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -37,8 +37,12 @@ pipelines:
     input:
         type: file
         watching_dir: /var/lib/docker/containers
+        paths:
+          include:
+            - '**\/*-json.log' # remove \
+          exclude:
+            - ef933707fe551f512d0b240558fdd01771f7897cccab75eb4fab0e575393ab79
         offsets_file: /data/offsets.yaml
-        filename_pattern: "*-json.log"
         persistence_mode: async
 ```
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -30,21 +30,6 @@ But update events don't work with symlinks, so watcher also periodically manuall
 
 > ⚠ Use add_file_name plugin if you want to add filename to events.
 
-**Reading docker container log files:**
-```yaml
-pipelines:
-  example_docker_pipeline:
-    input:
-        type: file
-        paths:
-          include:
-            - '/var/lib/docker/containers/**\/*-json.log' # remove \
-          exclude:
-            - '/var/lib/docker/containers/19aa5027343f4*\/*-json.log' # remove \
-        offsets_file: /data/offsets.yaml
-        persistence_mode: async
-```
-
 [More details...](plugin/input/file/README.md)
 ## http
 Reads events from HTTP requests with the body delimited by a new line.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -36,12 +36,11 @@ pipelines:
   example_docker_pipeline:
     input:
         type: file
-        watching_dir: /var/lib/docker/containers
         paths:
           include:
-            - '**\/*-json.log' # remove \
+            - '/var/lib/docker/containers/**\/*-json.log' # remove \
           exclude:
-            - ef933707fe551f512d0b240558fdd01771f7897cccab75eb4fab0e575393ab79
+            - '/var/lib/docker/containers/19aa5027343f4*\/*-json.log' # remove \
         offsets_file: /data/offsets.yaml
         persistence_mode: async
 ```

--- a/plugin/input/README.md
+++ b/plugin/input/README.md
@@ -29,21 +29,6 @@ But update events don't work with symlinks, so watcher also periodically manuall
 
 > ⚠ Use add_file_name plugin if you want to add filename to events.
 
-**Reading docker container log files:**
-```yaml
-pipelines:
-  example_docker_pipeline:
-    input:
-        type: file
-        paths:
-          include:
-            - '/var/lib/docker/containers/**\/*-json.log' # remove \
-          exclude:
-            - '/var/lib/docker/containers/19aa5027343f4*\/*-json.log' # remove \
-        offsets_file: /data/offsets.yaml
-        persistence_mode: async
-```
-
 [More details...](plugin/input/file/README.md)
 ## http
 Reads events from HTTP requests with the body delimited by a new line.

--- a/plugin/input/README.md
+++ b/plugin/input/README.md
@@ -36,8 +36,12 @@ pipelines:
     input:
         type: file
         watching_dir: /var/lib/docker/containers
+        paths:
+          include:
+            - '**\/*-json.log' # remove \
+          exclude:
+            - ef933707fe551f512d0b240558fdd01771f7897cccab75eb4fab0e575393ab79
         offsets_file: /data/offsets.yaml
-        filename_pattern: "*-json.log"
         persistence_mode: async
 ```
 

--- a/plugin/input/README.md
+++ b/plugin/input/README.md
@@ -35,12 +35,11 @@ pipelines:
   example_docker_pipeline:
     input:
         type: file
-        watching_dir: /var/lib/docker/containers
         paths:
           include:
-            - '**\/*-json.log' # remove \
+            - '/var/lib/docker/containers/**\/*-json.log' # remove \
           exclude:
-            - ef933707fe551f512d0b240558fdd01771f7897cccab75eb4fab0e575393ab79
+            - '/var/lib/docker/containers/19aa5027343f4*\/*-json.log' # remove \
         offsets_file: /data/offsets.yaml
         persistence_mode: async
 ```

--- a/plugin/input/file/README.idoc.md
+++ b/plugin/input/file/README.idoc.md
@@ -1,6 +1,21 @@
 # File plugin
 @introduction
 
+**Reading docker container log files:**
+```yaml
+pipelines:
+  example_docker_pipeline:
+    input:
+        type: file
+        paths:
+          include:
+            - '/var/lib/docker/containers/**/*-json.log'
+          exclude:
+            - '/var/lib/docker/containers/19aa5027343f4*/*-json.log'
+        offsets_file: /data/offsets.yaml
+        persistence_mode: async
+```
+
 ### Config params
 @config-params|description
 

--- a/plugin/input/file/README.md
+++ b/plugin/input/file/README.md
@@ -35,13 +35,13 @@ pipelines:
 ```
 
 ### Config params
-**`watching_dir`** *`string`* *`required`* 
+**`watching_dir`** *`string`* 
 
 List of included pathes
-*`string`* *`required`* 
+*`string`* 
 
 List of excluded pathes
-*`string`* *`required`* 
+*`string`* 
 
 The source directory to watch for files to process. All subdirectories also will be watched. E.g. if files have
 `/var/my-logs/$YEAR/$MONTH/$DAY/$HOST/$FACILITY-$PROGRAM.log` structure, `watching_dir` should be `/var/my-logs`.

--- a/plugin/input/file/README.md
+++ b/plugin/input/file/README.md
@@ -25,12 +25,11 @@ pipelines:
   example_docker_pipeline:
     input:
         type: file
-        watching_dir: /var/lib/docker/containers
         paths:
           include:
-            - '**\/*-json.log' # remove \
+            - '/var/lib/docker/containers/**\/*-json.log' # remove \
           exclude:
-            - ef933707fe551f512d0b240558fdd01771f7897cccab75eb4fab0e575393ab79
+            - '/var/lib/docker/containers/19aa5027343f4*\/*-json.log' # remove \
         offsets_file: /data/offsets.yaml
         persistence_mode: async
 ```

--- a/plugin/input/file/README.md
+++ b/plugin/input/file/README.md
@@ -27,33 +27,20 @@ pipelines:
         type: file
         paths:
           include:
-            - '/var/lib/docker/containers/**\/*-json.log' # remove \
+            - '/var/lib/docker/containers/**/*-json.log'
           exclude:
-            - '/var/lib/docker/containers/19aa5027343f4*\/*-json.log' # remove \
+            - '/var/lib/docker/containers/19aa5027343f4*/*-json.log'
         offsets_file: /data/offsets.yaml
         persistence_mode: async
 ```
 
 ### Config params
-**`watching_dir`** *`string`* 
-
-List of included pathes
-*`string`* 
-
-List of excluded pathes
-*`string`* 
-
-The source directory to watch for files to process. All subdirectories also will be watched. E.g. if files have
-`/var/my-logs/$YEAR/$MONTH/$DAY/$HOST/$FACILITY-$PROGRAM.log` structure, `watching_dir` should be `/var/my-logs`.
-Also the `filename_pattern`/`dir_pattern` is useful to filter needless files/subdirectories. In the case of using two or more
-different directories, it's recommended to setup separate pipelines for each.
-
-<br>
-
 **`paths`** *`Paths`* 
 
-Paths.
-> Check out [func Glob docs](https://golang.org/pkg/path/filepath/#Glob) for details.
+Set paths in glob format
+
+* `include` *`[]string`*
+* `exclude` *`[]string`*
 
 <br>
 
@@ -61,20 +48,6 @@ Paths.
 
 The filename to store offsets of processed files. Offsets are loaded only on initialization.
 > It's a `yaml` file. You can modify it manually.
-
-<br>
-
-**`filename_pattern`** *`string`* *`default=*`* 
-
-Files that don't meet this pattern will be ignored.
-> Check out [func Glob docs](https://golang.org/pkg/path/filepath/#Glob) for details.
-
-<br>
-
-**`dir_pattern`** *`string`* *`default=*`* 
-
-Dirs that don't meet this pattern will be ignored.
-> Check out [func Glob docs](https://golang.org/pkg/path/filepath/#Glob) for details.
 
 <br>
 
@@ -160,6 +133,29 @@ Add meta information to an event (look at Meta params)
 Use [go-template](https://pkg.go.dev/text/template) syntax
 
 Example: ```filename: '{{ .filename }}'```
+
+<br>
+
+**`watching_dir`** **Deprecated format**
+
+The source directory to watch for files to process. All subdirectories also will be watched. E.g. if files have
+`/var/my-logs/$YEAR/$MONTH/$DAY/$HOST/$FACILITY-$PROGRAM.log` structure, `watching_dir` should be `/var/my-logs`.
+Also the `filename_pattern`/`dir_pattern` is useful to filter needless files/subdirectories. In the case of using two or more
+different directories, it's recommended to setup separate pipelines for each.
+
+<br>
+
+**`filename_pattern`** *`string`* *`default=*`* 
+
+Files that don't meet this pattern will be ignored.
+> Check out [func Glob docs](https://golang.org/pkg/path/filepath/#Glob) for details.
+
+<br>
+
+**`dir_pattern`** *`string`* *`default=*`* 
+
+Dirs that don't meet this pattern will be ignored.
+> Check out [func Glob docs](https://golang.org/pkg/path/filepath/#Glob) for details.
 
 <br>
 

--- a/plugin/input/file/README.md
+++ b/plugin/input/file/README.md
@@ -26,18 +26,35 @@ pipelines:
     input:
         type: file
         watching_dir: /var/lib/docker/containers
+        paths:
+          include:
+            - '**\/*-json.log' # remove \
+          exclude:
+            - ef933707fe551f512d0b240558fdd01771f7897cccab75eb4fab0e575393ab79
         offsets_file: /data/offsets.yaml
-        filename_pattern: "*-json.log"
         persistence_mode: async
 ```
 
 ### Config params
 **`watching_dir`** *`string`* *`required`* 
 
+List of included pathes
+*`string`* *`required`* 
+
+List of excluded pathes
+*`string`* *`required`* 
+
 The source directory to watch for files to process. All subdirectories also will be watched. E.g. if files have
 `/var/my-logs/$YEAR/$MONTH/$DAY/$HOST/$FACILITY-$PROGRAM.log` structure, `watching_dir` should be `/var/my-logs`.
 Also the `filename_pattern`/`dir_pattern` is useful to filter needless files/subdirectories. In the case of using two or more
 different directories, it's recommended to setup separate pipelines for each.
+
+<br>
+
+**`paths`** *`Paths`* 
+
+Paths.
+> Check out [func Glob docs](https://golang.org/pkg/path/filepath/#Glob) for details.
 
 <br>
 

--- a/plugin/input/file/file.go
+++ b/plugin/input/file/file.go
@@ -34,21 +34,6 @@ But update events don't work with symlinks, so watcher also periodically manuall
 > By default the plugin is notified only on file creations. Note that following for changes is more CPU intensive.
 
 > ⚠ Use add_file_name plugin if you want to add filename to events.
-
-**Reading docker container log files:**
-```yaml
-pipelines:
-  example_docker_pipeline:
-    input:
-        type: file
-        paths:
-          include:
-            - '/var/lib/docker/containers/**\/*-json.log' # remove \
-          exclude:
-            - '/var/lib/docker/containers/19aa5027343f4*\/*-json.log' # remove \
-        offsets_file: /data/offsets.yaml
-        persistence_mode: async
-```
 }*/
 
 type Plugin struct {
@@ -85,14 +70,7 @@ const (
 )
 
 type Paths struct {
-	// > @3@4@5@6
-	// >
-	// > List of included pathes
 	Include []string `json:"include"`
-
-	// > @3@4@5@6
-	// >
-	// > List of excluded pathes
 	Exclude []string `json:"exclude"`
 }
 
@@ -102,16 +80,10 @@ type Config struct {
 
 	// > @3@4@5@6
 	// >
-	// > The source directory to watch for files to process. All subdirectories also will be watched. E.g. if files have
-	// > `/var/my-logs/$YEAR/$MONTH/$DAY/$HOST/$FACILITY-$PROGRAM.log` structure, `watching_dir` should be `/var/my-logs`.
-	// > Also the `filename_pattern`/`dir_pattern` is useful to filter needless files/subdirectories. In the case of using two or more
-	// > different directories, it's recommended to setup separate pipelines for each.
-	WatchingDir string `json:"watching_dir"` // *
-
-	// > @3@4@5@6
+	// > Set paths in glob format
 	// >
-	// > Paths.
-	// > > Check out [func Glob docs](https://golang.org/pkg/path/filepath/#Glob) for details.
+	// > * `include` *`[]string`*
+	// > * `exclude` *`[]string`*
 	Paths Paths `json:"paths"` // *
 
 	// > @3@4@5@6
@@ -120,18 +92,6 @@ type Config struct {
 	// > > It's a `yaml` file. You can modify it manually.
 	OffsetsFile    string `json:"offsets_file" required:"true"` // *
 	OffsetsFileTmp string
-
-	// > @3@4@5@6
-	// >
-	// > Files that don't meet this pattern will be ignored.
-	// > > Check out [func Glob docs](https://golang.org/pkg/path/filepath/#Glob) for details.
-	FilenamePattern string `json:"filename_pattern" default:"*"` // *
-
-	// > @3@4@5@6
-	// >
-	// > Dirs that don't meet this pattern will be ignored.
-	// > > Check out [func Glob docs](https://golang.org/pkg/path/filepath/#Glob) for details.
-	DirPattern string `json:"dir_pattern" default:"*"` // *
 
 	// > @3@4@5@6
 	// >
@@ -205,6 +165,26 @@ type Config struct {
 	// >
 	// > Example: ```filename: '{{ .filename }}'```
 	Meta cfg.MetaTemplates `json:"meta"` // *
+
+	// > **Deprecated format**
+	// >
+	// > The source directory to watch for files to process. All subdirectories also will be watched. E.g. if files have
+	// > `/var/my-logs/$YEAR/$MONTH/$DAY/$HOST/$FACILITY-$PROGRAM.log` structure, `watching_dir` should be `/var/my-logs`.
+	// > Also the `filename_pattern`/`dir_pattern` is useful to filter needless files/subdirectories. In the case of using two or more
+	// > different directories, it's recommended to setup separate pipelines for each.
+	WatchingDir string `json:"watching_dir"` // *
+
+	// > @3@4@5@6
+	// >
+	// > Files that don't meet this pattern will be ignored.
+	// > > Check out [func Glob docs](https://golang.org/pkg/path/filepath/#Glob) for details.
+	FilenamePattern string `json:"filename_pattern" default:"*"` // *
+
+	// > @3@4@5@6
+	// >
+	// > Dirs that don't meet this pattern will be ignored.
+	// > > Check out [func Glob docs](https://golang.org/pkg/path/filepath/#Glob) for details.
+	DirPattern string `json:"dir_pattern" default:"*"` // *
 }
 
 var offsetFiles = make(map[string]string)

--- a/plugin/input/file/file.go
+++ b/plugin/input/file/file.go
@@ -41,12 +41,11 @@ pipelines:
   example_docker_pipeline:
     input:
         type: file
-        watching_dir: /var/lib/docker/containers
         paths:
           include:
-            - '**\/*-json.log' # remove \
+            - '/var/lib/docker/containers/**\/*-json.log' # remove \
           exclude:
-            - ef933707fe551f512d0b240558fdd01771f7897cccab75eb4fab0e575393ab79
+            - '/var/lib/docker/containers/19aa5027343f4*\/*-json.log' # remove \
         offsets_file: /data/offsets.yaml
         persistence_mode: async
 ```

--- a/plugin/input/file/file.go
+++ b/plugin/input/file/file.go
@@ -42,8 +42,12 @@ pipelines:
     input:
         type: file
         watching_dir: /var/lib/docker/containers
+        paths:
+          include:
+            - '**\/*-json.log' # remove \
+          exclude:
+            - ef933707fe551f512d0b240558fdd01771f7897cccab75eb4fab0e575393ab79
         offsets_file: /data/offsets.yaml
-        filename_pattern: "*-json.log"
         persistence_mode: async
 ```
 }*/
@@ -81,6 +85,18 @@ const (
 	offsetsOpReset                     // * `reset` – resets an offset to the beginning of the file
 )
 
+type Paths struct {
+	// > @3@4@5@6
+	// >
+	// > List of included pathes
+	Include []string `json:"include"`
+
+	// > @3@4@5@6
+	// >
+	// > List of excluded pathes
+	Exclude []string `json:"exclude"`
+}
+
 type Config struct {
 	// ! config-params
 	// ^ config-params
@@ -92,6 +108,12 @@ type Config struct {
 	// > Also the `filename_pattern`/`dir_pattern` is useful to filter needless files/subdirectories. In the case of using two or more
 	// > different directories, it's recommended to setup separate pipelines for each.
 	WatchingDir string `json:"watching_dir" required:"true"` // *
+
+	// > @3@4@5@6
+	// >
+	// > Paths.
+	// > > Check out [func Glob docs](https://golang.org/pkg/path/filepath/#Glob) for details.
+	Paths Paths `json:"paths"` // *
 
 	// > @3@4@5@6
 	// >

--- a/plugin/input/file/file.go
+++ b/plugin/input/file/file.go
@@ -106,7 +106,7 @@ type Config struct {
 	// > `/var/my-logs/$YEAR/$MONTH/$DAY/$HOST/$FACILITY-$PROGRAM.log` structure, `watching_dir` should be `/var/my-logs`.
 	// > Also the `filename_pattern`/`dir_pattern` is useful to filter needless files/subdirectories. In the case of using two or more
 	// > different directories, it's recommended to setup separate pipelines for each.
-	WatchingDir string `json:"watching_dir" required:"true"` // *
+	WatchingDir string `json:"watching_dir"` // *
 
 	// > @3@4@5@6
 	// >

--- a/plugin/input/file/file.go
+++ b/plugin/input/file/file.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/ozontech/file.d/cfg"
 	"github.com/ozontech/file.d/fd"
 	"github.com/ozontech/file.d/metric"
@@ -221,6 +222,20 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.InputPluginPa
 		)
 	} else {
 		offsetFiles[offsetFilePath] = params.PipelineName
+	}
+
+	for _, pattern := range p.config.Paths.Include {
+		_, err := doublestar.PathMatch(pattern, ".")
+		if err != nil {
+			p.logger.Fatalf("wrong paths include pattern %q: %s", pattern, err.Error())
+		}
+	}
+
+	for _, pattern := range p.config.Paths.Exclude {
+		_, err := doublestar.PathMatch(pattern, ".")
+		if err != nil {
+			p.logger.Fatalf("wrong paths exclude pattern %q: %s", pattern, err.Error())
+		}
 	}
 
 	p.jobProvider = NewJobProvider(

--- a/plugin/input/file/info.go
+++ b/plugin/input/file/info.go
@@ -45,10 +45,16 @@ func (ir *InfoRegistry) Info(w http.ResponseWriter, r *http.Request) {
 
 	_, _ = w.Write([]byte(jobsInfo))
 
-	watcherInfo := logger.Header("watch_dirs")
+	watcherInfo := logger.Header("watch_paths")
+	for _, source := range plugin.jobProvider.watcher.basePaths {
+		watcherInfo += fmt.Sprintf(
+			"%s\n",
+			source,
+		)
+	}
 	watcherInfo += fmt.Sprintf(
-		"%s\n",
-		plugin.jobProvider.watcher.path,
+		"commonPath: %s\n",
+		plugin.jobProvider.watcher.commonPath,
 	)
 	_, _ = w.Write([]byte(watcherInfo))
 

--- a/plugin/input/file/provider.go
+++ b/plugin/input/file/provider.go
@@ -145,10 +145,23 @@ func NewJobProvider(config *Config, metrics *metricCollection, sugLogger *zap.Su
 		numberOfCurrentJobsMetric:      metrics.numberOfCurrentJobsMetric,
 	}
 
+	if len(config.Paths.Include) == 0 {
+		if config.DirPattern == "*" {
+			config.Paths.Include = append(
+				config.Paths.Include,
+				filepath.Join("**", config.FilenamePattern),
+			)
+		} else {
+			config.Paths.Include = append(
+				config.Paths.Include,
+				filepath.Join(config.DirPattern, config.FilenamePattern),
+			)
+		}
+	}
+
 	jp.watcher = NewWatcher(
 		config.WatchingDir,
-		config.FilenamePattern,
-		config.DirPattern,
+		config.Paths,
 		jp.processNotification,
 		config.ShouldWatchChanges,
 		metrics.notifyChannelLengthMetric,

--- a/plugin/input/file/provider.go
+++ b/plugin/input/file/provider.go
@@ -149,12 +149,12 @@ func NewJobProvider(config *Config, metrics *metricCollection, sugLogger *zap.Su
 		if config.DirPattern == "*" {
 			config.Paths.Include = append(
 				config.Paths.Include,
-				filepath.Join("**", config.FilenamePattern),
+				filepath.Join(config.WatchingDir, filepath.Join("**", config.FilenamePattern)),
 			)
 		} else {
 			config.Paths.Include = append(
 				config.Paths.Include,
-				filepath.Join(config.DirPattern, config.FilenamePattern),
+				filepath.Join(config.WatchingDir, filepath.Join(config.DirPattern, config.FilenamePattern)),
 			)
 		}
 	}

--- a/plugin/input/file/provider_test.go
+++ b/plugin/input/file/provider_test.go
@@ -132,6 +132,7 @@ func TestProvierWatcherPaths(t *testing.T) {
 				ctl.RegisterCounter("worker1", "help_test"),
 				ctl.RegisterCounter("worker2", "help_test"),
 				ctl.RegisterGauge("worker3", "help_test"),
+				ctl.RegisterGauge("worker4", "help_test"),
 			)
 			jp := NewJobProvider(config, metrics, &zap.SugaredLogger{})
 

--- a/plugin/input/file/provider_test.go
+++ b/plugin/input/file/provider_test.go
@@ -129,9 +129,9 @@ func TestProvierWatcherPaths(t *testing.T) {
 			config := tt.config
 			test.NewConfig(config, map[string]int{"gomaxprocs": runtime.GOMAXPROCS(0)})
 			metrics := newMetricCollection(
-				ctl.RegisterCounter("worker", "help_test"),
-				ctl.RegisterCounter("worker", "help_test"),
-				ctl.RegisterGauge("worker", "help_test"),
+				ctl.RegisterCounter("worker1", "help_test"),
+				ctl.RegisterCounter("worker2", "help_test"),
+				ctl.RegisterGauge("worker3", "help_test"),
 			)
 			jp := NewJobProvider(config, metrics, &zap.SugaredLogger{})
 

--- a/plugin/input/file/provider_test.go
+++ b/plugin/input/file/provider_test.go
@@ -70,7 +70,7 @@ func TestProvierWatcherPaths(t *testing.T) {
 				OffsetsFile: "offset.json",
 			},
 			expectedPathes: Paths{
-				Include: []string{"**/*"},
+				Include: []string{"/var/log/**/*"},
 			},
 		},
 		{
@@ -81,7 +81,7 @@ func TestProvierWatcherPaths(t *testing.T) {
 				OffsetsFile:     "offset.json",
 			},
 			expectedPathes: Paths{
-				Include: []string{"**/error.log"},
+				Include: []string{"/var/log/**/error.log"},
 			},
 		},
 		{
@@ -93,7 +93,7 @@ func TestProvierWatcherPaths(t *testing.T) {
 				OffsetsFile:     "offset.json",
 			},
 			expectedPathes: Paths{
-				Include: []string{"nginx-ingress-*/error.log"},
+				Include: []string{"/var/log/nginx-ingress-*/error.log"},
 			},
 		},
 		{
@@ -104,7 +104,7 @@ func TestProvierWatcherPaths(t *testing.T) {
 				OffsetsFile: "offset.json",
 			},
 			expectedPathes: Paths{
-				Include: []string{"nginx-ingress-*/*"},
+				Include: []string{"/var/log/nginx-ingress-*/*"},
 			},
 		},
 		{
@@ -115,11 +115,11 @@ func TestProvierWatcherPaths(t *testing.T) {
 				DirPattern:      "nginx-ingress-*",
 				OffsetsFile:     "offset.json",
 				Paths: Paths{
-					Include: []string{"access.log"},
+					Include: []string{"/var/log/access.log"},
 				},
 			},
 			expectedPathes: Paths{
-				Include: []string{"access.log"},
+				Include: []string{"/var/log/access.log"},
 			},
 		},
 	}

--- a/plugin/input/file/provider_test.go
+++ b/plugin/input/file/provider_test.go
@@ -47,4 +47,95 @@ func TestRefreshSymlinkOnBrokenLink(t *testing.T) {
 	os.Remove(linkName)
 	jp.maintenanceSymlinks()
 	require.Equal(t, 0, len(jp.symlinks))
+	"runtime"
+	"testing"
+
+	"github.com/ozontech/file.d/metric"
+	"github.com/ozontech/file.d/test"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestProvierWatcherPaths(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         *Config
+		expectedPathes Paths
+	}{
+		{
+			name: "default config",
+			config: &Config{
+				WatchingDir: "/var/log/",
+				OffsetsFile: "offset.json",
+			},
+			expectedPathes: Paths{
+				Include: []string{"**/*"},
+			},
+		},
+		{
+			name: "filename pattern config",
+			config: &Config{
+				WatchingDir:     "/var/log/",
+				FilenamePattern: "error.log",
+				OffsetsFile:     "offset.json",
+			},
+			expectedPathes: Paths{
+				Include: []string{"**/error.log"},
+			},
+		},
+		{
+			name: "filename and dir pattern config",
+			config: &Config{
+				WatchingDir:     "/var/log/",
+				FilenamePattern: "error.log",
+				DirPattern:      "nginx-ingress-*",
+				OffsetsFile:     "offset.json",
+			},
+			expectedPathes: Paths{
+				Include: []string{"nginx-ingress-*/error.log"},
+			},
+		},
+		{
+			name: "dir pattern config",
+			config: &Config{
+				WatchingDir: "/var/log/",
+				DirPattern:  "nginx-ingress-*",
+				OffsetsFile: "offset.json",
+			},
+			expectedPathes: Paths{
+				Include: []string{"nginx-ingress-*/*"},
+			},
+		},
+		{
+			name: "ignore filename and dir pattern",
+			config: &Config{
+				WatchingDir:     "/var/log/",
+				FilenamePattern: "error.log",
+				DirPattern:      "nginx-ingress-*",
+				OffsetsFile:     "offset.json",
+				Paths: Paths{
+					Include: []string{"access.log"},
+				},
+			},
+			expectedPathes: Paths{
+				Include: []string{"access.log"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctl := metric.NewCtl("test", prometheus.NewRegistry())
+			config := tt.config
+			test.NewConfig(config, map[string]int{"gomaxprocs": runtime.GOMAXPROCS(0)})
+			metrics := newMetricCollection(
+				ctl.RegisterCounter("worker", "help_test"),
+				ctl.RegisterCounter("worker", "help_test"),
+				ctl.RegisterGauge("worker", "help_test"),
+			)
+			jp := NewJobProvider(config, metrics, &zap.SugaredLogger{})
+
+			assert.Equal(t, tt.expectedPathes, jp.watcher.paths)
+		})
+	}
 }

--- a/plugin/input/file/provider_test.go
+++ b/plugin/input/file/provider_test.go
@@ -5,11 +5,17 @@ import (
 	"path/filepath"
 	"testing"
 
+	"runtime"
+
 	"github.com/ozontech/file.d/logger"
 	"github.com/ozontech/file.d/metric"
 	"github.com/prometheus/client_golang/prometheus"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ozontech/file.d/test"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 )
 
 func TestRefreshSymlinkOnBrokenLink(t *testing.T) {
@@ -47,15 +53,7 @@ func TestRefreshSymlinkOnBrokenLink(t *testing.T) {
 	os.Remove(linkName)
 	jp.maintenanceSymlinks()
 	require.Equal(t, 0, len(jp.symlinks))
-	"runtime"
-	"testing"
-
-	"github.com/ozontech/file.d/metric"
-	"github.com/ozontech/file.d/test"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
-)
+}
 
 func TestProvierWatcherPaths(t *testing.T) {
 	tests := []struct {

--- a/plugin/input/file/watcher.go
+++ b/plugin/input/file/watcher.go
@@ -152,10 +152,12 @@ func (w *watcher) notify(e notify.Event, path string) {
 
 	if stat.IsDir() {
 		dirFilename := filename
+	check_dir:
 		for {
 			for _, path := range w.basePaths {
 				if path == dirFilename {
 					w.tryAddPath(filename)
+					break check_dir
 				}
 			}
 			if dirFilename == w.commonPath {
@@ -164,6 +166,20 @@ func (w *watcher) notify(e notify.Event, path string) {
 			dirFilename = filepath.Dir(dirFilename)
 		}
 		return
+	}
+
+	dirFilename := filepath.Dir(filename)
+check_file:
+	for {
+		for _, path := range w.basePaths {
+			if path == dirFilename {
+				break check_file
+			}
+		}
+		if dirFilename == w.commonPath {
+			return
+		}
+		dirFilename = filepath.Dir(dirFilename)
 	}
 
 	w.logger.Infof("%s %s", e, path)

--- a/plugin/input/file/watcher.go
+++ b/plugin/input/file/watcher.go
@@ -135,6 +135,8 @@ func (w *watcher) notify(e notify.Event, path string) {
 		return
 	}
 
+	w.logger.Infof("notify %s %s", e, path)
+
 	for _, pattern := range w.paths.Exclude {
 		match, err := doublestar.PathMatch(pattern, path)
 		if err != nil {
@@ -142,6 +144,7 @@ func (w *watcher) notify(e notify.Event, path string) {
 			return
 		}
 		if match {
+			w.logger.Infof("excluded %s by pattern %s", path, pattern)
 			return
 		}
 	}
@@ -183,8 +186,6 @@ check_file:
 		dirFilename = filepath.Dir(dirFilename)
 	}
 
-	w.logger.Infof("%s %s", e, path)
-
 	for _, pattern := range w.paths.Include {
 		match, err := doublestar.PathMatch(pattern, path)
 		if err != nil {
@@ -193,6 +194,7 @@ check_file:
 		}
 
 		if match {
+			w.logger.Infof("path %s matched by pattern %s", filename, pattern)
 			w.notifyFn(e, filename, stat)
 		}
 	}

--- a/plugin/input/file/watcher.go
+++ b/plugin/input/file/watcher.go
@@ -111,20 +111,21 @@ func (w *watcher) stop() {
 }
 
 func (w *watcher) tryAddPath(path string) {
-	files, err := os.ReadDir(path)
-	if err != nil {
-		return
-	}
-
 	w.logger.Infof("starting path watch: %s ", path)
 
-	for _, file := range files {
-		if file.Name() == "" || file.Name() == "." || file.Name() == ".." {
-			continue
-		}
-
-		filename := filepath.Join(path, file.Name())
-		w.notify(notify.Create, filename)
+	err := filepath.Walk(path,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if !info.IsDir() {
+				w.notify(notify.Create, path)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return
 	}
 }
 

--- a/plugin/input/file/watcher.go
+++ b/plugin/input/file/watcher.go
@@ -140,7 +140,7 @@ func (w *watcher) notify(e notify.Event, path string) {
 	for _, pattern := range w.paths.Exclude {
 		match, err := doublestar.PathMatch(pattern, path)
 		if err != nil {
-			w.logger.Fatalf("wrong paths exclude pattern %q: %s", pattern, err.Error())
+			w.logger.Errorf("wrong paths exclude pattern %q: %s", pattern, err.Error())
 			return
 		}
 		if match {
@@ -189,7 +189,7 @@ check_file:
 	for _, pattern := range w.paths.Include {
 		match, err := doublestar.PathMatch(pattern, path)
 		if err != nil {
-			w.logger.Fatalf("wrong paths include pattern %q: %s", pattern, err.Error())
+			w.logger.Errorf("wrong paths include pattern %q: %s", pattern, err.Error())
 			return
 		}
 

--- a/plugin/input/file/watcher_test.go
+++ b/plugin/input/file/watcher_test.go
@@ -29,16 +29,23 @@ func TestWatcher(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			path := t.TempDir()
+			dir := t.TempDir()
 			shouldCreate := atomic.Int64{}
 			notifyFn := func(_ notify.Event, _ string, _ os.FileInfo) {
 				shouldCreate.Inc()
 			}
 			ctl := metric.NewCtl("test", prometheus.NewRegistry())
 			w := NewWatcher(
-				path,
-				tt.filenamePattern,
-				tt.dirPattern,
+				dir,
+				Paths{
+					Include: []string{
+						tt.dirPattern,
+						filepath.Join(
+							tt.dirPattern,
+							tt.filenamePattern,
+						),
+					},
+				},
 				notifyFn,
 				false,
 				ctl.RegisterGauge("worker", "help_test"),
@@ -49,14 +56,14 @@ func TestWatcher(t *testing.T) {
 
 			// create, write, remove files and ensure events are only passed for creation events.
 
-			f1Name := filepath.Join(path, "watch1.log")
+			f1Name := filepath.Join(dir, "watch1.log")
 
 			f1, err := os.Create(f1Name)
 			require.NoError(t, err)
 			err = f1.Close()
 			require.NoError(t, err)
 
-			f2, err := os.Create(filepath.Join(path, "watch2.log"))
+			f2, err := os.Create(filepath.Join(dir, "watch2.log"))
 			require.NoError(t, err)
 			err = f2.Close()
 			require.NoError(t, err)
@@ -78,6 +85,108 @@ func TestWatcher(t *testing.T) {
 			time.Sleep(10 * time.Millisecond)
 
 			require.Equal(t, int64(2), shouldCreate.Load())
+		})
+	}
+}
+
+func TestWatcherPaths(t *testing.T) {
+	dir := t.TempDir()
+	shouldCreate := atomic.Int64{}
+	notifyFn := func(_ notify.Event, _ string, _ os.FileInfo) {
+		shouldCreate.Inc()
+	}
+	ctl := metric.NewCtl("test", prometheus.NewRegistry())
+	w := NewWatcher(
+		dir,
+		Paths{
+			Include: []string{
+				"nginx-ingress-*/error.log",
+				"log/**/*",
+				"access.log",
+				"**/sub_access.log",
+			},
+			Exclude: []string{
+				"log/payments/**",
+				"nginx-ingress-payments/error.log",
+			},
+		},
+		notifyFn,
+		false,
+		ctl.RegisterGauge("worker", "help_test"),
+		zap.L().Sugar(),
+	)
+	w.start()
+	defer w.stop()
+
+	tests := []struct {
+		name         string
+		filename     string
+		shouldNotify bool
+	}{
+		{
+			filename:     "nginx-ingress-0/error.log",
+			shouldNotify: true,
+		},
+		{
+			filename:     "log/errors.log",
+			shouldNotify: true,
+		},
+		{
+			filename:     "log/0/errors.log",
+			shouldNotify: true,
+		},
+		{
+			filename:     "log/0/0/errors.log",
+			shouldNotify: true,
+		},
+		{
+			filename:     "access.log",
+			shouldNotify: true,
+		},
+		{
+			filename:     "sub_access.log",
+			shouldNotify: true,
+		},
+		{
+			filename:     "access1.log",
+			shouldNotify: false,
+		},
+		{
+			filename:     "nginx/errors.log",
+			shouldNotify: false,
+		},
+		{
+			filename:     "log/payments/errors.log",
+			shouldNotify: false,
+		},
+		{
+			filename:     "log/payments/nginx-ingress-0/errors.log",
+			shouldNotify: false,
+		},
+		{
+			filename:     "nginx-ingress-payments/error.log",
+			shouldNotify: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.filename, func(t *testing.T) {
+			filename := filepath.Join(dir, tt.filename)
+
+			err := os.MkdirAll(filepath.Dir(filename), 0o700)
+			require.NoError(t, err)
+
+			f1, err := os.Create(filename)
+			require.NoError(t, err)
+			err = f1.Close()
+			require.NoError(t, err)
+
+			before := shouldCreate.Load()
+			w.notify(notify.Create, filename)
+			after := shouldCreate.Load()
+
+			isNotified := after-before != 0
+			require.Equal(t, tt.shouldNotify, isNotified)
 		})
 	}
 }

--- a/plugin/input/file/watcher_test.go
+++ b/plugin/input/file/watcher_test.go
@@ -88,6 +88,7 @@ func TestWatcher(t *testing.T) {
 	}
 }
 
+// nolint:gocritic
 func TestWatcherPaths(t *testing.T) {
 	dir := t.TempDir()
 	shouldCreate := atomic.Int64{}


### PR DESCRIPTION
try to define watching_dir from paths.include

see also #566 

```
pipelines:
  welcome:
    input:
      type: file
      persistence_mode: async
      # watching_dir: /var/lib/docker/containers 
      # filename_pattern: "*-json.log"
      paths:
        include:
          - '/var/lib/docker/containers/30b28763e40a7649ef73c8afce0b0f4e62546f2a07a174d97e56bd02854facbd/*-json.log'
          - '/var/lib/docker/containers/65d343a9cc0a9fe6e466a370fcaf8ad6458eb912d19f8e8832e941e2ab7cafa0/*-json.log'
          - '/var/lib/docker/containers/**/*-json.log'
          - '/var/log/clickhouse-server/*.log'
        exclude:
          - '/var/lib/docker/overlay2/**'
          - '/var/lib/docker/volumes/**'
      offsets_file: ./offsets.yaml
      offsets_op: reset
    output:
      type: stdout

```