### PR TITLE
Some performance optimizations to the MetricHolder

### DIFF
--- a/metric/held_counter.go
+++ b/metric/held_counter.go
@@ -1,0 +1,43 @@
+package metric
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type HeldCounter struct {
+	*heldMetric[prometheus.Counter]
+}
+
+func (h HeldCounter) Inc() {
+	h.metric.Inc()
+	h.updateUsage()
+}
+
+func (h HeldCounter) Add(v float64) {
+	h.metric.Add(v)
+	h.updateUsage()
+}
+
+type HeldCounterVec struct {
+	store *heldMetricsStore[prometheus.Counter]
+	vec   *prometheus.CounterVec
+}
+
+func NewHeldCounterVec(cv *prometheus.CounterVec) HeldCounterVec {
+	return HeldCounterVec{
+		vec:   cv,
+		store: newHeldLabelsStore[prometheus.Counter](),
+	}
+}
+
+func (h HeldCounterVec) WithLabelValues(lvs ...string) HeldCounter {
+	return HeldCounter{
+		heldMetric: h.store.GetOrCreate(lvs, h.vec.WithLabelValues),
+	}
+}
+
+func (h HeldCounterVec) ReleaseOldMetrics(holdDuration time.Duration) {
+	h.store.ReleaseOldMetrics(holdDuration, h.vec)
+}

--- a/metric/held_counter.go
+++ b/metric/held_counter.go
@@ -38,6 +38,6 @@ func (h HeldCounterVec) WithLabelValues(lvs ...string) HeldCounter {
 	}
 }
 
-func (h HeldCounterVec) ReleaseOldMetrics(holdDuration time.Duration) {
-	h.store.ReleaseOldMetrics(holdDuration, h.vec)
+func (h HeldCounterVec) DeleteOldMetrics(holdDuration time.Duration) {
+	h.store.DeleteOldMetrics(holdDuration, h.vec)
 }

--- a/metric/held_counter.go
+++ b/metric/held_counter.go
@@ -28,7 +28,7 @@ type HeldCounterVec struct {
 func NewHeldCounterVec(cv *prometheus.CounterVec) HeldCounterVec {
 	return HeldCounterVec{
 		vec:   cv,
-		store: newHeldLabelsStore[prometheus.Counter](),
+		store: newHeldMetricsStore[prometheus.Counter](),
 	}
 }
 

--- a/metric/held_gauge.go
+++ b/metric/held_gauge.go
@@ -53,6 +53,6 @@ func (h HeldGaugeVec) WithLabelValues(lvs ...string) HeldGauge {
 	}
 }
 
-func (h HeldGaugeVec) ReleaseOldMetrics(holdDuration time.Duration) {
-	h.store.ReleaseOldMetrics(holdDuration, h.vec)
+func (h HeldGaugeVec) DeleteOldMetrics(holdDuration time.Duration) {
+	h.store.DeleteOldMetrics(holdDuration, h.vec)
 }

--- a/metric/held_gauge.go
+++ b/metric/held_gauge.go
@@ -1,0 +1,58 @@
+package metric
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type HeldGauge struct {
+	*heldMetric[prometheus.Gauge]
+}
+
+func (h HeldGauge) Set(v float64) {
+	h.metric.Set(v)
+	h.updateUsage()
+}
+
+func (h HeldGauge) Inc() {
+	h.metric.Inc()
+	h.updateUsage()
+}
+
+func (h HeldGauge) Dec() {
+	h.metric.Dec()
+	h.updateUsage()
+}
+
+func (h HeldGauge) Add(v float64) {
+	h.metric.Add(v)
+	h.updateUsage()
+}
+
+func (h HeldGauge) Sub(v float64) {
+	h.metric.Sub(v)
+	h.updateUsage()
+}
+
+type HeldGaugeVec struct {
+	store *heldMetricsStore[prometheus.Gauge]
+	vec   *prometheus.GaugeVec
+}
+
+func NewHeldGaugeVec(gv *prometheus.GaugeVec) HeldGaugeVec {
+	return HeldGaugeVec{
+		vec:   gv,
+		store: newHeldLabelsStore[prometheus.Gauge](),
+	}
+}
+
+func (h HeldGaugeVec) WithLabelValues(lvs ...string) HeldGauge {
+	return HeldGauge{
+		heldMetric: h.store.GetOrCreate(lvs, h.vec.WithLabelValues),
+	}
+}
+
+func (h HeldGaugeVec) ReleaseOldMetrics(holdDuration time.Duration) {
+	h.store.ReleaseOldMetrics(holdDuration, h.vec)
+}

--- a/metric/held_gauge.go
+++ b/metric/held_gauge.go
@@ -43,7 +43,7 @@ type HeldGaugeVec struct {
 func NewHeldGaugeVec(gv *prometheus.GaugeVec) HeldGaugeVec {
 	return HeldGaugeVec{
 		vec:   gv,
-		store: newHeldLabelsStore[prometheus.Gauge](),
+		store: newHeldMetricsStore[prometheus.Gauge](),
 	}
 }
 

--- a/metric/held_histogram.go
+++ b/metric/held_histogram.go
@@ -35,6 +35,6 @@ func (h HeldHistogramVec) WithLabelValues(lvs ...string) HeldHistogram {
 	}
 }
 
-func (h HeldHistogramVec) ReleaseOldMetrics(holdDuration time.Duration) {
-	h.store.ReleaseOldMetrics(holdDuration, h.vec)
+func (h HeldHistogramVec) DeleteOldMetrics(holdDuration time.Duration) {
+	h.store.DeleteOldMetrics(holdDuration, h.vec)
 }

--- a/metric/held_histogram.go
+++ b/metric/held_histogram.go
@@ -23,7 +23,7 @@ type HeldHistogramVec struct {
 func NewHeldHistogramVec(hv *prometheus.HistogramVec) HeldHistogramVec {
 	return HeldHistogramVec{
 		vec:   hv,
-		store: newHeldLabelsStore[prometheus.Histogram](),
+		store: newHeldMetricsStore[prometheus.Histogram](),
 	}
 }
 

--- a/metric/held_histogram.go
+++ b/metric/held_histogram.go
@@ -1,0 +1,40 @@
+package metric
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type HeldHistogram struct {
+	*heldMetric[prometheus.Histogram]
+}
+
+func (h HeldHistogram) Observe(v float64) {
+	h.metric.Observe(v)
+	h.updateUsage()
+}
+
+type HeldHistogramVec struct {
+	store *heldMetricsStore[prometheus.Histogram]
+	vec   *prometheus.HistogramVec
+}
+
+func NewHeldHistogramVec(hv *prometheus.HistogramVec) HeldHistogramVec {
+	return HeldHistogramVec{
+		vec:   hv,
+		store: newHeldLabelsStore[prometheus.Histogram](),
+	}
+}
+
+func (h HeldHistogramVec) WithLabelValues(lvs ...string) HeldHistogram {
+	return HeldHistogram{
+		heldMetric: h.store.GetOrCreate(lvs, func(s ...string) prometheus.Histogram {
+			return h.vec.WithLabelValues(s...).(prometheus.Histogram)
+		}),
+	}
+}
+
+func (h HeldHistogramVec) ReleaseOldMetrics(holdDuration time.Duration) {
+	h.store.ReleaseOldMetrics(holdDuration, h.vec)
+}

--- a/metric/held_metric.go
+++ b/metric/held_metric.go
@@ -2,6 +2,7 @@ package metric
 
 import (
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -17,12 +18,16 @@ type heldMetric[T prometheus.Metric] struct {
 	metric    T
 }
 
-func newHeldMetric[T prometheus.Metric](lvs []string, metric T) *heldMetric[T] {
-	labels := make([]string, len(lvs))
-	// copy labels because they are unsafe strings
-	copy(labels, lvs)
+func newHeldMetric[T prometheus.Metric](labels []string, metric T) *heldMetric[T] {
+	// copy labels because they are unsafe converted bytes
+	// TODO: replace with [][]byte to make it explicit
+	labelsCopy := make([]string, len(labels))
+	for i := range labels {
+		labelsCopy[i] = strings.Clone(labels[i])
+	}
+
 	hl := &heldMetric[T]{
-		labels:    labels,
+		labels:    labelsCopy,
 		lastUsage: atomic.Int64{},
 		metric:    metric,
 	}

--- a/metric/held_metric_test.go
+++ b/metric/held_metric_test.go
@@ -22,12 +22,13 @@ func TestLabelExpiration(t *testing.T) {
 	now := time.Now().UnixNano()
 	xtime.SetNowTime(now)
 
-	// 1 error
 	c.WithLabelValues("error").Inc()
-	// 2 warns
 	c.WithLabelValues("warn").Inc()
-	// 2 infos
 	c.WithLabelValues("info").Inc()
+
+	r.Equal(3, len(c.store.metricsByHash))
+	c.DeleteOldMetrics(time.Minute)
+	r.Equal(3, len(c.store.metricsByHash))
 
 	// update usage of the metric with "info" label
 	{

--- a/metric/held_metric_test.go
+++ b/metric/held_metric_test.go
@@ -8,42 +8,62 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func BenchmarkMetricWithLabels(b *testing.B) {
-	benchCases := []struct {
-		Labels      []string
-		LabelValues [][]string
-	}{
-		{
-			Labels: []string{"first"},
-			LabelValues: [][]string{
-				{"test1"},
-				{"test2"},
-				{"test3"},
-			},
+var holderBenchCases = []struct {
+	Labels      []string
+	LabelValues [][]string
+}{
+	{
+		Labels: []string{"l1"},
+		LabelValues: [][]string{
+			{"test1"},
+			{"test2"},
+			{"test3"},
 		},
-		{
-			Labels: []string{"first", "second"},
-			LabelValues: [][]string{
-				{"first1", "second1"},
-				{"first2", "second2"},
-				{"first3", "second3"},
-			},
+	},
+	{
+		Labels: []string{"l1", "l2"},
+		LabelValues: [][]string{
+			{"first1", "second1"},
+			{"first2", "second2"},
+			{"first3", "second3"},
 		},
-		{
-			Labels: []string{"first", "second", "third"},
-			LabelValues: [][]string{
-				{"first1", "second1", "third1"},
-				{"first2", "second2", "third2"},
-				{"first3", "second3", "third3"},
-			},
+	},
+	{
+		Labels: []string{"l1", "l2", "l3"},
+		LabelValues: [][]string{
+			{"first1", "second1", "third1"},
+			{"first2", "second2", "third2"},
+			{"first3", "second3", "third3"},
 		},
-	}
+	},
+}
 
-	for _, benchCase := range benchCases {
+func BenchmarkMetricHolder(b *testing.B) {
+	for _, benchCase := range holderBenchCases {
 		ctl := NewCtl("test", prometheus.NewRegistry())
 		holder := NewHolder(time.Minute)
-		counter := holder.AddCounterVec(ctl.RegisterCounterVec("test_name", "", benchCase.Labels...))
 
+		promCounter := ctl.RegisterCounterVec("test_name", "", benchCase.Labels...)
+		counter := holder.AddCounterVec(promCounter)
+
+		name := strings.Join(benchCase.Labels, "_")
+
+		b.Run(name, func(b *testing.B) {
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					for _, labels := range benchCase.LabelValues {
+						counter.WithLabelValues(labels...).Inc()
+					}
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkPromVec(b *testing.B) {
+	for _, benchCase := range holderBenchCases {
+		ctl := NewCtl("test", prometheus.NewRegistry())
+		counter := ctl.RegisterCounterVec("test_name", "", benchCase.Labels...)
 		name := strings.Join(benchCase.Labels, "_")
 
 		b.Run(name, func(b *testing.B) {

--- a/metric/held_metric_test.go
+++ b/metric/held_metric_test.go
@@ -4,9 +4,26 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
 )
+
+func TestUnsafeStringInMetric(t *testing.T) {
+	r := require.New(t)
+
+	bytes := []byte("hello world")
+	unsafeString := unsafe.String(unsafe.SliceData(bytes), len(bytes))
+
+	labels := []string{unsafeString}
+	m := newHeldMetric[prometheus.Counter]([]string{unsafeString}, prometheus.NewCounter(prometheus.CounterOpts{}))
+
+	bytes[0] = '1'
+	labels[0] = "new"
+
+	r.Equal([]string{"hello world"}, m.labels)
+}
 
 var holderBenchCases = []struct {
 	Labels      []string

--- a/metric/held_metric_test.go
+++ b/metric/held_metric_test.go
@@ -1,138 +1,59 @@
 package metric
 
 import (
-	"slices"
-	"sync/atomic"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/testutil"
-	"github.com/stretchr/testify/require"
 )
 
-func TestDeleteObsoleteMetrics(t *testing.T) {
-	type testHeldLabels struct {
-		labelValues []string
-		isObsolete  bool
-	}
-
-	type testCaseData struct {
-		metric string
-		labels []string
-
-		heldLabelsMap map[uint64][]testHeldLabels
-	}
-
-	type testCase struct {
-		vec   *prometheus.CounterVec
-		hlVec *heldLabelsVec
-
-		wantMap          map[uint64][]heldLabels
-		wantCountMetrics int
-	}
-
-	prepareTestCase := func(tcData testCaseData) testCase {
-		cv := prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: "test",
-			Subsystem: "test",
-			Name:      tcData.metric,
-			Help:      "help",
-		}, tcData.labels)
-		prometheus.MustRegister(cv)
-
-		hlVec := &heldLabelsVec{
-			heldLabelsByHash: map[uint64][]heldLabels{},
-		}
-
-		m := map[uint64][]heldLabels{}
-		countMetrics := 0
-		for k, v := range tcData.heldLabelsMap {
-			hlVec.heldLabelsByHash[k] = make([]heldLabels, len(v))
-			for i, hl := range v {
-				isObs := hl.isObsolete
-				hlVec.heldLabelsByHash[k][i] = heldLabels{
-					labels:         hl.labelValues,
-					lastUsage:      new(atomic.Int64),
-					isObsoleteFunc: func(int64, time.Duration) bool { return isObs },
-				}
-
-				if !isObs {
-					m[k] = append(m[k], heldLabels{labels: hl.labelValues})
-					countMetrics++
-				}
-
-				cv.WithLabelValues(hl.labelValues...).Inc()
-			}
-		}
-
-		return testCase{
-			vec:              cv,
-			hlVec:            hlVec,
-			wantMap:          m,
-			wantCountMetrics: countMetrics,
-		}
-	}
-
-	tests := []struct {
-		name   string
-		tcData testCaseData
+func BenchmarkMetricWithLabels(b *testing.B) {
+	benchCases := []struct {
+		Labels      []string
+		LabelValues [][]string
 	}{
 		{
-			name: "with_labels",
-			tcData: testCaseData{
-				metric: "metric1",
-				labels: []string{"lbl1", "lbl2"},
-				heldLabelsMap: map[uint64][]testHeldLabels{
-					1: {
-						testHeldLabels{labelValues: []string{"val1_1_1", "val1_1_2"}, isObsolete: true},
-						testHeldLabels{labelValues: []string{"val1_2_1", "val1_2_2"}, isObsolete: false},
-					},
-					2: {testHeldLabels{labelValues: []string{"val2_1", "val2_2"}, isObsolete: false}},
-					3: {testHeldLabels{labelValues: []string{"val3_1", "val3_2"}, isObsolete: true}},
-				},
+			Labels: []string{"first"},
+			LabelValues: [][]string{
+				{"test1"},
+				{"test2"},
+				{"test3"},
 			},
 		},
 		{
-			name: "no_labels_obsolete",
-			tcData: testCaseData{
-				metric: "metric2",
-				heldLabelsMap: map[uint64][]testHeldLabels{
-					1: {testHeldLabels{labelValues: nil, isObsolete: true}},
-				},
+			Labels: []string{"first", "second"},
+			LabelValues: [][]string{
+				{"first1", "second1"},
+				{"first2", "second2"},
+				{"first3", "second3"},
 			},
 		},
 		{
-			name: "no_labels_no_obsolete",
-			tcData: testCaseData{
-				metric: "metric3",
-				heldLabelsMap: map[uint64][]testHeldLabels{
-					1: {testHeldLabels{labelValues: nil, isObsolete: false}},
-				},
+			Labels: []string{"first", "second", "third"},
+			LabelValues: [][]string{
+				{"first1", "second1", "third1"},
+				{"first2", "second2", "third2"},
+				{"first3", "second3", "third3"},
 			},
 		},
 	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 
-			tc := prepareTestCase(tt.tcData)
+	for _, benchCase := range benchCases {
+		ctl := NewCtl("test", prometheus.NewRegistry())
+		holder := NewHolder(time.Minute)
+		counter := holder.AddCounterVec(ctl.RegisterCounterVec("test_name", "", benchCase.Labels...))
 
-			deleteObsoleteMetrics(time.Second, tc.hlVec, tc.vec.MetricVec)
+		name := strings.Join(benchCase.Labels, "_")
 
-			require.Equal(t, tc.wantCountMetrics, testutil.CollectAndCount(tc.vec))
-			require.Equal(t, len(tc.wantMap), len(tc.hlVec.heldLabelsByHash))
-			for k, v := range tc.hlVec.heldLabelsByHash {
-				wantHl := tc.wantMap[k]
-				require.Equal(t, len(wantHl), len(v))
-				for i, hl := range v {
-					require.True(t, slices.Equal(wantHl[i].labels, hl.labels))
-					require.Equal(t, float64(1), testutil.ToFloat64(tc.vec.WithLabelValues(hl.labels...)))
+		b.Run(name, func(b *testing.B) {
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					for _, labels := range benchCase.LabelValues {
+						counter.WithLabelValues(labels...).Inc()
+					}
 				}
-			}
-
-			prometheus.Unregister(tc.vec)
+			})
 		})
 	}
 }

--- a/metric/held_metric_test.go
+++ b/metric/held_metric_test.go
@@ -49,13 +49,11 @@ func BenchmarkMetricHolder(b *testing.B) {
 		name := strings.Join(benchCase.Labels, "_")
 
 		b.Run(name, func(b *testing.B) {
-			b.RunParallel(func(pb *testing.PB) {
-				for pb.Next() {
-					for _, labels := range benchCase.LabelValues {
-						counter.WithLabelValues(labels...).Inc()
-					}
+			for i := 0; i < b.N; i++ {
+				for _, labels := range benchCase.LabelValues {
+					counter.WithLabelValues(labels...).Inc()
 				}
-			})
+			}
 		})
 	}
 }
@@ -67,13 +65,11 @@ func BenchmarkPromVec(b *testing.B) {
 		name := strings.Join(benchCase.Labels, "_")
 
 		b.Run(name, func(b *testing.B) {
-			b.RunParallel(func(pb *testing.PB) {
-				for pb.Next() {
-					for _, labels := range benchCase.LabelValues {
-						counter.WithLabelValues(labels...).Inc()
-					}
+			for i := 0; i < b.N; i++ {
+				for _, labels := range benchCase.LabelValues {
+					counter.WithLabelValues(labels...).Inc()
 				}
-			})
+			}
 		})
 	}
 }

--- a/metric/holder.go
+++ b/metric/holder.go
@@ -27,7 +27,7 @@ func NewHolder(holdDuration time.Duration) *Holder {
 }
 
 func (h *Holder) Maintenance() {
-	h.releaseOldMetrics()
+	h.DeleteOldMetrics()
 }
 
 func (h *Holder) AddCounterVec(counterVec *prometheus.CounterVec) HeldCounterVec {
@@ -48,8 +48,8 @@ func (h *Holder) AddHistogramVec(histogramVec *prometheus.HistogramVec) HeldHist
 	return hhv
 }
 
-// releaseOldMetrics delete old metric labels, that aren't in use since last update.
-func (h *Holder) releaseOldMetrics() {
+// DeleteOldMetrics delete old metric labels, that aren't in use since last update.
+func (h *Holder) DeleteOldMetrics() {
 	for i := range h.heldMetrics {
 		h.heldMetrics[i].DeleteOldMetrics(h.holdDuration)
 	}

--- a/metric/holder.go
+++ b/metric/holder.go
@@ -7,7 +7,7 @@ import (
 )
 
 type heldMetricVec interface {
-	ReleaseOldMetrics(holdDuration time.Duration)
+	DeleteOldMetrics(holdDuration time.Duration)
 }
 
 type Holder struct {
@@ -51,6 +51,6 @@ func (h *Holder) AddHistogramVec(histogramVec *prometheus.HistogramVec) HeldHist
 // releaseOldMetrics delete old metric labels, that aren't in use since last update.
 func (h *Holder) releaseOldMetrics() {
 	for i := range h.heldMetrics {
-		h.heldMetrics[i].ReleaseOldMetrics(h.holdDuration)
+		h.heldMetrics[i].DeleteOldMetrics(h.holdDuration)
 	}
 }

--- a/metric/holder.go
+++ b/metric/holder.go
@@ -7,7 +7,7 @@ import (
 )
 
 type heldMetricVec interface {
-	update(holdDuration time.Duration)
+	ReleaseOldMetrics(holdDuration time.Duration)
 }
 
 type Holder struct {
@@ -15,7 +15,11 @@ type Holder struct {
 	heldMetrics  []heldMetricVec
 }
 
+// NewHolder returns new metric holder. The holdDuration must be more than 1m.
 func NewHolder(holdDuration time.Duration) *Holder {
+	if holdDuration < time.Minute {
+		panic("hold duration must be greater than 1m")
+	}
 	return &Holder{
 		holdDuration: holdDuration,
 		heldMetrics:  make([]heldMetricVec, 0),
@@ -23,30 +27,30 @@ func NewHolder(holdDuration time.Duration) *Holder {
 }
 
 func (h *Holder) Maintenance() {
-	h.updateMetrics()
+	h.releaseOldMetrics()
 }
 
-func (h *Holder) AddCounterVec(counterVec *prometheus.CounterVec) *HeldCounterVec {
-	hcv := newHeldCounterVec(counterVec)
+func (h *Holder) AddCounterVec(counterVec *prometheus.CounterVec) HeldCounterVec {
+	hcv := NewHeldCounterVec(counterVec)
 	h.heldMetrics = append(h.heldMetrics, hcv)
 	return hcv
 }
 
-func (h *Holder) AddGaugeVec(gaugeVec *prometheus.GaugeVec) *HeldGaugeVec {
-	hgv := newHeldGaugeVec(gaugeVec)
+func (h *Holder) AddGaugeVec(gaugeVec *prometheus.GaugeVec) HeldGaugeVec {
+	hgv := NewHeldGaugeVec(gaugeVec)
 	h.heldMetrics = append(h.heldMetrics, hgv)
 	return hgv
 }
 
-func (h *Holder) AddHistogramVec(histogramVec *prometheus.HistogramVec) *HeldHistogramVec {
-	hhv := newHeldHistogramVec(histogramVec)
+func (h *Holder) AddHistogramVec(histogramVec *prometheus.HistogramVec) HeldHistogramVec {
+	hhv := NewHeldHistogramVec(histogramVec)
 	h.heldMetrics = append(h.heldMetrics, hhv)
 	return hhv
 }
 
-// updateMetrics delete old metrics, that aren't in use since last update.
-func (h *Holder) updateMetrics() {
+// releaseOldMetrics delete old metric labels, that aren't in use since last update.
+func (h *Holder) releaseOldMetrics() {
 	for i := range h.heldMetrics {
-		h.heldMetrics[i].update(h.holdDuration)
+		h.heldMetrics[i].ReleaseOldMetrics(h.holdDuration)
 	}
 }

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -539,8 +539,8 @@ func (p *Pipeline) finalize(event *Event, notifyInput bool, backEvent bool) {
 }
 
 type actionMetric struct {
-	count *metric.HeldCounterVec
-	size  *metric.HeldCounterVec
+	count metric.HeldCounterVec
+	size  metric.HeldCounterVec
 	// totalCounter is a map of eventStatus to counter for `/info` endpoint.
 	totalCounter map[string]*atomic.Uint64
 }

--- a/xtime/xtime.go
+++ b/xtime/xtime.go
@@ -27,7 +27,7 @@ func GetInaccurateTime() time.Time {
 	return time.Unix(0, GetInaccurateUnixNano())
 }
 
-// SetNowTime tests the current time.
+// SetNowTime sets the current time.
 // Function should be used only in tests.
 //
 // An alternative to this approach is to store and redefine

--- a/xtime/xtime.go
+++ b/xtime/xtime.go
@@ -1,25 +1,11 @@
 package xtime
 
 import (
-	"sync"
 	"sync/atomic"
 	"time"
 )
 
-const updateTimeInterval = time.Second
-
-var nowTime atomic.Int64
-
-func GetInaccurateUnixNano() int64 {
-	startOnce()
-	return nowTime.Load()
-}
-
-func GetInaccurateTime() time.Time {
-	return time.Unix(0, GetInaccurateUnixNano())
-}
-
-var startOnce = sync.OnceFunc(func() {
+func init() {
 	setNowTime(time.Now())
 	ticker := time.NewTicker(updateTimeInterval)
 	go func() {
@@ -27,7 +13,19 @@ var startOnce = sync.OnceFunc(func() {
 			setNowTime(t)
 		}
 	}()
-})
+}
+
+const updateTimeInterval = time.Second
+
+var nowTime atomic.Int64
+
+func GetInaccurateUnixNano() int64 {
+	return nowTime.Load()
+}
+
+func GetInaccurateTime() time.Time {
+	return time.Unix(0, GetInaccurateUnixNano())
+}
 
 func setNowTime(t time.Time) {
 	nowTime.Store(t.UnixNano())

--- a/xtime/xtime.go
+++ b/xtime/xtime.go
@@ -6,11 +6,11 @@ import (
 )
 
 func init() {
-	setNowTime(time.Now())
+	SetNowTime(time.Now().UnixNano())
 	ticker := time.NewTicker(updateTimeInterval)
 	go func() {
 		for t := range ticker.C {
-			setNowTime(t)
+			SetNowTime(t.UnixNano())
 		}
 	}()
 }
@@ -27,6 +27,12 @@ func GetInaccurateTime() time.Time {
 	return time.Unix(0, GetInaccurateUnixNano())
 }
 
-func setNowTime(t time.Time) {
-	nowTime.Store(t.UnixNano())
+// SetNowTime tests the current time.
+// Function should be used only in tests.
+//
+// An alternative to this approach is to store and redefine
+// a function through the fields of the tested struct.
+// But in this case, the inlining function GetInaccurateUnixNano is lost.
+func SetNowTime(unixNano int64) {
+	nowTime.Store(unixNano)
 }


### PR DESCRIPTION
metricholder takes up a significant amount of CPU on our profile. This PR adds several optimizations. The main optimizations are:

1) Calculating prometheus.MetricVec.WithLabelValues() once, not for every .Inc/.Set/etc
2) Optimization of hash calculation when there is only 1 label
3) Using xxhash for hashing
4) Reduce the amount of memory allocation in the heap
5) Update lastUsage atomic every 10 seconds, not every .Inc/.Set/etc

(sorted by decreasing impact on the benchmark)

old:
```
$ go test -bench='Benchmark(MetricHolder)' -run=XXX -benchmem ./...
goos: darwin
goarch: arm64
pkg: github.com/ozontech/file.d/metric
BenchmarkMetricHolder/l1-8               3806335               299.4 ns/op           240 B/op          6 allocs/op
BenchmarkMetricHolder/l1_l2-8            2969712               404.7 ns/op           288 B/op          6 allocs/op
BenchmarkMetricHolder/l1_l2_l3-8         2462668               487.5 ns/op           336 B/op          6 allocs/op
PASS
ok      github.com/ozontech/file.d/metric       5.006s
```

new:
```
$ go test -bench='Benchmark(MetricHolder)' -run=XXX -benchmem ./...
goos: darwin
goarch: arm64
pkg: github.com/ozontech/file.d/metric
BenchmarkMetricHolder/l1-8              19625188                60.72 ns/op            0 B/op          0 allocs/op
BenchmarkMetricHolder/l1_l2-8           16686858                71.55 ns/op            0 B/op          0 allocs/op
BenchmarkMetricHolder/l1_l2_l3-8        12369921                97.69 ns/op            0 B/op          0 allocs/op
PASS
ok      github.com/ozontech/file.d/metric       5.217s
```


prom:
```
$ go test -bench='Benchmark(Prom)' -run=XXX -benchmem ./...
goos: darwin
goarch: arm64
pkg: github.com/ozontech/file.d/metric
BenchmarkPromVec/l1-8            7012634               165.3 ns/op            48 B/op          3 allocs/op
BenchmarkPromVec/l1_l2-8         4787998               250.3 ns/op            96 B/op          3 allocs/op
BenchmarkPromVec/l1_l2_l3-8      3826999               316.3 ns/op           144 B/op          3 allocs/op
PASS
ok      github.com/ozontech/file.d/metric       4.440s
```

TODO: 

- [X] Tests
- [X] Benchmark prometheus.MetricVec
- [X] Benchmark result old/new