### PR TITLE
598 modify plugin trim filter

### DIFF
--- a/cfg/substitution/filter.go
+++ b/cfg/substitution/filter.go
@@ -1,0 +1,137 @@
+package substitution
+
+import (
+	"fmt"
+	"strings"
+
+	"go.uber.org/zap"
+)
+
+const (
+	regexFilterPrefix = "re("
+	trimFilterPrefix  = "trim("
+
+	bufInitSize = 1024
+)
+
+type FieldFilter interface {
+	// Apply accepts src and dst slices of bytes and returns result stored in modified src slice.
+	// src slice is needed to avoid unnecessary allocations.
+	Apply(src []byte, dst []byte) []byte
+
+	setBuffer([]byte)
+	compareArgs([]any) error
+}
+
+// parseFilterOps parses a chain of field filters from substitution string
+// `${field|filter1|filter2|...|filterN}` -> `<filter1>,<filter2>,...,<filterN>`.
+func parseFilterOps(substitution string, pipePos, endPos int, filterBuf []byte, logger *zap.Logger) ([]FieldFilter, error) {
+	var filterOps []FieldFilter
+	offset := 0
+	for pipePos != -1 {
+		pipePos += offset
+		filterOp, filterEndPos, err := parseFilter(substitution[pipePos+1:endPos], logger)
+		if err != nil {
+			return nil, err
+		}
+		// single buffer for all filters because there is only one event for a substitution op simultaneously
+		// and filters in substitution op are applied sequentially one by one
+		if filterBuf == nil {
+			filterBuf = make([]byte, 0, bufInitSize)
+		}
+		filterOp.setBuffer(filterBuf)
+		filterOps = append(filterOps, filterOp)
+		offset = pipePos + 1 + filterEndPos
+		pipePos = indexRuneInExpr(substitution[offset:endPos], '|', true, false)
+	}
+	return filterOps, nil
+}
+
+// parseFilter parses filter data from string with filter args if present in format "<filter-name>(<arg1>, <arg2>, ...)".
+func parseFilter(data string, logger *zap.Logger) (FieldFilter, int, error) {
+	origDataLen := len(data)
+	data = strings.TrimLeft(data, " ")
+	offset := origDataLen - len(data)
+	if strings.HasPrefix(data, regexFilterPrefix) {
+		return parseRegexFilter(data, offset, logger)
+	} else if strings.HasPrefix(data, trimFilterPrefix) {
+		return parseTrimFilter(data, offset)
+	}
+	return nil, -1, errInvalidFilter
+}
+
+// parseFilterArgs parses args from string in format of "<arg1>, <arg2>, ...)" --
+// filter args without its name and starting bracket.
+func parseFilterArgs(data string) ([]string, int, error) {
+	var args []string
+	// no args
+	if data[0] == ')' {
+		return args, 0, nil
+	}
+	argsEndPos := -1
+	quotesOpened := quotesOpenedNo
+	brackets := make([]byte, 0, 100)
+	curArg := make([]byte, 0, 100)
+	// parse args separated by comma ','
+	// re("((),()),()", [1, 2, 3], "'(,)'")
+gatherLoop:
+	for i, b := range []byte(data) {
+		// escaped characters handling
+		if i != 0 && data[i-1] == '\\' {
+			curArg = append(curArg, b)
+			continue
+		}
+		// quotes have a priority over brackets
+		switch {
+		case quotesOpened == quotesOpenedNo:
+			switch {
+			case b == '\'':
+				quotesOpened = quotesOpenedSingle
+			case b == '"':
+				quotesOpened = quotesOpenedDouble
+			case b == '(' || b == '[' || b == '{':
+				brackets = append(brackets, b)
+			case b == ')' && len(brackets) == 0:
+				// early stop on the end of args list
+				argsEndPos = i
+				break gatherLoop
+			case b == ')' || b == ']':
+				lastBracket := brackets[len(brackets)-1]
+				switch {
+				case b == ')' && lastBracket != '(':
+					return nil, argsEndPos, fmt.Errorf("invalid brackets: %s", data)
+				case b == ']' && lastBracket != '[':
+					return nil, argsEndPos, fmt.Errorf("invalid brackets: %s", data)
+				}
+				brackets = brackets[:len(brackets)-1]
+			case b == ',' && len(brackets) == 0:
+				// condition for separating args
+				args = append(args, string(curArg))
+				curArg = curArg[:0]
+				continue gatherLoop
+			}
+		case b == '\'' && quotesOpened == quotesOpenedSingle:
+			quotesOpened = quotesOpenedNo
+		case b == '"' && quotesOpened == quotesOpenedDouble:
+			quotesOpened = quotesOpenedNo
+		}
+		curArg = append(curArg, b)
+	}
+	if len(brackets) > 0 {
+		return nil, argsEndPos, fmt.Errorf("invalid brackets: %s", data)
+	}
+	if quotesOpened != quotesOpenedNo {
+		return nil, argsEndPos, fmt.Errorf("not all quotes are closed: %s", data)
+	}
+	if argsEndPos == -1 {
+		return nil, argsEndPos, fmt.Errorf("no closing bracket for args list: %s", data)
+	}
+	// last arg
+	if len(curArg) > 0 {
+		args = append(args, string(curArg))
+	}
+	for i := range args {
+		args[i] = strings.TrimSpace(args[i])
+	}
+	return args, argsEndPos, nil
+}

--- a/cfg/substitution/regex_filter.go
+++ b/cfg/substitution/regex_filter.go
@@ -1,0 +1,128 @@
+package substitution
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+
+	"github.com/ozontech/file.d/cfg"
+	"go.uber.org/zap"
+)
+
+type RegexFilter struct {
+	re        *regexp.Regexp
+	limit     int
+	groups    []int
+	separator []byte
+
+	buf []byte
+}
+
+func (r *RegexFilter) Apply(src []byte, dst []byte) []byte {
+	if len(r.groups) == 0 {
+		return dst
+	}
+	indexes := r.re.FindAllSubmatchIndex(src, r.limit)
+	if len(indexes) == 0 {
+		return dst
+	}
+	r.buf = r.buf[:0]
+	for _, index := range indexes {
+		for _, grp := range r.groups {
+			// (*regexp.Regexp).FindAllSubmatchIndex(...) returns a slice of indexes in format:
+			// [<start of whole regexp match>, <end of whole regexp match>, <start of group 1>, <end of group 1>, ...].
+			// So if there are more than one group in regexp the first two indexes must be skipped.
+			// Start of group 1 is index[2], end of group 1 is index[3], start of group 2 is index[4], end of group 2 is index[5],
+			// and so on. Hence, the start of group i is index[2*i], the end of group i is index[2*i+1].
+			start := index[grp*2]
+			end := index[grp*2+1]
+			if len(r.separator) > 0 && len(r.buf) != 0 {
+				r.buf = append(r.buf, r.separator...)
+			}
+			r.buf = append(r.buf, src[start:end]...)
+		}
+	}
+	if cap(dst) < len(r.buf) {
+		dst = make([]byte, len(r.buf))
+	} else {
+		dst = dst[:len(r.buf)]
+	}
+	copy(dst, r.buf)
+	return dst
+}
+
+func (r *RegexFilter) setBuffer(buf []byte) {
+	r.buf = buf
+}
+
+// compareArgs is used for testing. Checks filter args values.
+func (r *RegexFilter) compareArgs(args []any) error {
+	wantArgsCnt := 4
+	if len(args) != wantArgsCnt {
+		return fmt.Errorf("wrong regex filter amount of args, want=%d got=%d", wantArgsCnt, len(args))
+	}
+	wantRe := args[0].(string)
+	gotRe := r.re.String()
+	if wantRe != gotRe {
+		return fmt.Errorf("wrong regex filter regex expr, want=%q got=%q", wantRe, gotRe)
+	}
+	wantLimit := args[1].(int)
+	gotLimit := r.limit
+	if wantLimit != gotLimit {
+		return fmt.Errorf("wrong regex filter limit, want=%v got=%v", wantLimit, gotLimit)
+	}
+	wantGroups := args[2].([]int)
+	gotGroups := r.groups
+	if len(wantGroups) != len(gotGroups) {
+		return fmt.Errorf("wrong regex filter groups, want=%v got=%v", wantGroups, gotGroups)
+	}
+	for i := 0; i < len(wantGroups); i++ {
+		if wantGroups[i] != gotGroups[i] {
+			return fmt.Errorf("wrong regex filter groups, want=%v got=%v", wantGroups, gotGroups)
+		}
+	}
+	wantSeparator := args[3].(string)
+	gotSeparator := string(r.separator)
+	if wantSeparator != gotSeparator {
+		return fmt.Errorf("wrong regex filter separator, want=%q got=%q", wantSeparator, gotSeparator)
+	}
+	return nil
+}
+
+func parseRegexFilter(data string, offset int, logger *zap.Logger) (FieldFilter, int, error) {
+	expArgsCnt := 4
+	filterEndPos := -1
+	args, argsEndPos, err := parseFilterArgs(data[len(regexFilterPrefix):])
+	if err != nil {
+		return nil, filterEndPos, fmt.Errorf("failed to parse filter args: %w", err)
+	}
+	filterEndPos = argsEndPos + len(regexFilterPrefix) + offset
+	if len(args) != expArgsCnt {
+		return nil, filterEndPos, fmt.Errorf("invalid args for regexp filter, exptected %d, got %d", expArgsCnt, len(args))
+	}
+	var reStr string
+	var limit int
+	var groups []int
+	var separator string
+	if err := json.Unmarshal([]byte(args[0]), &reStr); err != nil {
+		return nil, filterEndPos, fmt.Errorf("failed to parse regexp filter regexp string: %w", err)
+	}
+	re := regexp.MustCompile(reStr)
+	if err := json.Unmarshal([]byte(args[1]), &limit); err != nil {
+		return nil, filterEndPos, fmt.Errorf("failed to parse regexp filter limit: %w", err)
+	}
+	if err := json.Unmarshal([]byte(args[2]), &groups); err != nil {
+		return nil, filterEndPos, fmt.Errorf("failed to parse regexp filter groups: %w", err)
+	}
+	cfg.VerifyGroupNumbers(groups, re.NumSubexp(), logger)
+	if err := json.Unmarshal([]byte(args[3]), &separator); err != nil {
+		return nil, filterEndPos, fmt.Errorf("failed to parse regexp filter separator: %w", err)
+	}
+	filter := &RegexFilter{
+		re:        re,
+		limit:     limit,
+		groups:    groups,
+		separator: []byte(separator),
+	}
+	return filter, filterEndPos, nil
+}

--- a/cfg/substitution/substitution.go
+++ b/cfg/substitution/substitution.go
@@ -1,10 +1,8 @@
 package substitution
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/ozontech/file.d/cfg"
@@ -16,10 +14,6 @@ type SubstitutionOpKind int
 const (
 	SubstitutionOpKindRaw SubstitutionOpKind = iota
 	SubstitutionOpKindField
-
-	regexFilterPrefix = "re("
-
-	bufInitSize = 1024
 )
 
 type quotesOpenStatus int
@@ -31,95 +25,6 @@ const (
 )
 
 var errInvalidFilter = errors.New("invalid filter")
-
-type FieldFilter interface {
-	// Apply accepts src and dst slices of bytes and returns result stored in modified src slice.
-	// src slice is needed to avoid unnecessary allocations.
-	Apply(src []byte, dst []byte) []byte
-
-	setBuffer([]byte)
-	compareArgs([]any) error
-}
-
-type RegexFilter struct {
-	re        *regexp.Regexp
-	limit     int
-	groups    []int
-	separator []byte
-
-	buf []byte
-}
-
-func (r *RegexFilter) Apply(src []byte, dst []byte) []byte {
-	if len(r.groups) == 0 {
-		return dst
-	}
-	indexes := r.re.FindAllSubmatchIndex(src, r.limit)
-	if len(indexes) == 0 {
-		return dst
-	}
-	r.buf = r.buf[:0]
-	for _, index := range indexes {
-		for _, grp := range r.groups {
-			// (*regexp.Regexp).FindAllSubmatchIndex(...) returns a slice of indexes in format:
-			// [<start of whole regexp match>, <end of whole regexp match>, <start of group 1>, <end of group 1>, ...].
-			// So if there are more than one group in regexp the first two indexes must be skipped.
-			// Start of group 1 is index[2], end of group 1 is index[3], start of group 2 is index[4], end of group 2 is index[5],
-			// and so on. Hence, the start of group i is index[2*i], the end of group i is index[2*i+1].
-			start := index[grp*2]
-			end := index[grp*2+1]
-			if len(r.separator) > 0 && len(r.buf) != 0 {
-				r.buf = append(r.buf, r.separator...)
-			}
-			r.buf = append(r.buf, src[start:end]...)
-		}
-	}
-	if cap(dst) < len(r.buf) {
-		dst = make([]byte, len(r.buf))
-	} else {
-		dst = dst[:len(r.buf)]
-	}
-	copy(dst, r.buf)
-	return dst
-}
-
-func (r *RegexFilter) setBuffer(buf []byte) {
-	r.buf = buf
-}
-
-// compareArgs is used for testing. Checks filter args values.
-func (r *RegexFilter) compareArgs(args []any) error {
-	wantArgsCnt := 4
-	if len(args) != wantArgsCnt {
-		return fmt.Errorf("wrong regex filter amount of args, want=%d got=%d", wantArgsCnt, len(args))
-	}
-	wantRe := args[0].(string)
-	gotRe := r.re.String()
-	if wantRe != gotRe {
-		return fmt.Errorf("wrong regex filter regex expr, want=%q got=%q", wantRe, gotRe)
-	}
-	wantLimit := args[1].(int)
-	gotLimit := r.limit
-	if wantLimit != gotLimit {
-		return fmt.Errorf("wrong regex filter limit, want=%v got=%v", wantLimit, gotLimit)
-	}
-	wantGroups := args[2].([]int)
-	gotGroups := r.groups
-	if len(wantGroups) != len(gotGroups) {
-		return fmt.Errorf("wrong regex filter groups, want=%v got=%v", wantGroups, gotGroups)
-	}
-	for i := 0; i < len(wantGroups); i++ {
-		if wantGroups[i] != gotGroups[i] {
-			return fmt.Errorf("wrong regex filter groups, want=%v got=%v", wantGroups, gotGroups)
-		}
-	}
-	wantSeparator := args[3].(string)
-	gotSeparator := string(r.separator)
-	if wantSeparator != gotSeparator {
-		return fmt.Errorf("wrong regex filter separator, want=%q got=%q", wantSeparator, gotSeparator)
-	}
-	return nil
-}
 
 // indexRuneInExpr same as strings.IndexByte but depending on flags
 // considers sought rune is outside quotes and whether it is escaped explicitly
@@ -164,30 +69,6 @@ type SubstitutionOp struct {
 	Kind    SubstitutionOpKind
 	Data    []string
 	Filters []FieldFilter
-}
-
-// parseFilterOps parses a chain of field filters from substitution string
-// `${field|filter1|filter2|...|filterN}` -> `<filter1>,<filter2>,...,<filterN>`.
-func parseFilterOps(substitution string, pipePos, endPos int, filterBuf []byte, logger *zap.Logger) ([]FieldFilter, error) {
-	var filterOps []FieldFilter
-	offset := 0
-	for pipePos != -1 {
-		pipePos += offset
-		filterOp, filterEndPos, err := parseFilter(substitution[pipePos+1:endPos], logger)
-		if err != nil {
-			return nil, err
-		}
-		// single buffer for all filters because there is only one event for a substitution op simultaneously
-		// and filters in substitution op are applied sequentially one by one
-		if filterBuf == nil {
-			filterBuf = make([]byte, 0, bufInitSize)
-		}
-		filterOp.setBuffer(filterBuf)
-		filterOps = append(filterOps, filterOp)
-		offset = pipePos + 1 + filterEndPos
-		pipePos = indexRuneInExpr(substitution[offset:endPos], '|', true, false)
-	}
-	return filterOps, nil
 }
 
 func ParseSubstitution(substitution string, filtersBuf []byte, logger *zap.Logger) ([]SubstitutionOp, error) {
@@ -259,129 +140,4 @@ func ParseSubstitution(substitution string, filtersBuf []byte, logger *zap.Logge
 	}
 
 	return result, nil
-}
-
-func parseRegexFilter(data string, offset int, logger *zap.Logger) (FieldFilter, int, error) {
-	expArgsCnt := 4
-	filterEndPos := -1
-	args, argsEndPos, err := parseFilterArgs(data[len(regexFilterPrefix):])
-	if err != nil {
-		return nil, filterEndPos, fmt.Errorf("failed to parse filter args: %w", err)
-	}
-	filterEndPos = argsEndPos + len(regexFilterPrefix) + offset
-	if len(args) != expArgsCnt {
-		return nil, filterEndPos, fmt.Errorf("invalid args for regexp filter, exptected %d, got %d", expArgsCnt, len(args))
-	}
-	var reStr string
-	var limit int
-	var groups []int
-	var separator string
-	if err := json.Unmarshal([]byte(args[0]), &reStr); err != nil {
-		return nil, filterEndPos, fmt.Errorf("failed to parse regexp filter regexp string: %w", err)
-	}
-	re := regexp.MustCompile(reStr)
-	if err := json.Unmarshal([]byte(args[1]), &limit); err != nil {
-		return nil, filterEndPos, fmt.Errorf("failed to parse regexp filter limit: %w", err)
-	}
-	if err := json.Unmarshal([]byte(args[2]), &groups); err != nil {
-		return nil, filterEndPos, fmt.Errorf("failed to parse regexp filter groups: %w", err)
-	}
-	cfg.VerifyGroupNumbers(groups, re.NumSubexp(), logger)
-	if err := json.Unmarshal([]byte(args[3]), &separator); err != nil {
-		return nil, filterEndPos, fmt.Errorf("failed to parse regexp filter separator: %w", err)
-	}
-	filter := &RegexFilter{
-		re:        re,
-		limit:     limit,
-		groups:    groups,
-		separator: []byte(separator),
-	}
-	return filter, filterEndPos, nil
-}
-
-// parseFilter parses filter data from string with filter args if present in format "<filter-name>(<arg1>, <arg2>, ...)".
-func parseFilter(data string, logger *zap.Logger) (FieldFilter, int, error) {
-	origDataLen := len(data)
-	data = strings.TrimLeft(data, " ")
-	offset := origDataLen - len(data)
-	if strings.HasPrefix(data, regexFilterPrefix) {
-		return parseRegexFilter(data, offset, logger)
-	}
-	return nil, -1, errInvalidFilter
-}
-
-// parseFilterArgs parses args from string in format of "<arg1>, <arg2>, ...)" --
-// filter args without its name and starting bracket.
-func parseFilterArgs(data string) ([]string, int, error) {
-	var args []string
-	// no args
-	if data[0] == ')' {
-		return args, 0, nil
-	}
-	argsEndPos := -1
-	quotesOpened := quotesOpenedNo
-	brackets := make([]byte, 0, 100)
-	curArg := make([]byte, 0, 100)
-	// parse args separated by comma ','
-	// re("((),()),()", [1, 2, 3], "'(,)'")
-gatherLoop:
-	for i, b := range []byte(data) {
-		// escaped characters handling
-		if i != 0 && data[i-1] == '\\' {
-			curArg = append(curArg, b)
-			continue
-		}
-		// quotes have a priority over brackets
-		switch {
-		case quotesOpened == quotesOpenedNo:
-			switch {
-			case b == '\'':
-				quotesOpened = quotesOpenedSingle
-			case b == '"':
-				quotesOpened = quotesOpenedDouble
-			case b == '(' || b == '[' || b == '{':
-				brackets = append(brackets, b)
-			case b == ')' && len(brackets) == 0:
-				// early stop on the end of args list
-				argsEndPos = i
-				break gatherLoop
-			case b == ')' || b == ']':
-				lastBracket := brackets[len(brackets)-1]
-				switch {
-				case b == ')' && lastBracket != '(':
-					return nil, argsEndPos, fmt.Errorf("invalid brackets: %s", data)
-				case b == ']' && lastBracket != '[':
-					return nil, argsEndPos, fmt.Errorf("invalid brackets: %s", data)
-				}
-				brackets = brackets[:len(brackets)-1]
-			case b == ',' && len(brackets) == 0:
-				// condition for separating args
-				args = append(args, string(curArg))
-				curArg = curArg[:0]
-				continue gatherLoop
-			}
-		case b == '\'' && quotesOpened == quotesOpenedSingle:
-			quotesOpened = quotesOpenedNo
-		case b == '"' && quotesOpened == quotesOpenedDouble:
-			quotesOpened = quotesOpenedNo
-		}
-		curArg = append(curArg, b)
-	}
-	if len(brackets) > 0 {
-		return nil, argsEndPos, fmt.Errorf("invalid brackets: %s", data)
-	}
-	if quotesOpened != quotesOpenedNo {
-		return nil, argsEndPos, fmt.Errorf("not all quotes are closed: %s", data)
-	}
-	if argsEndPos == -1 {
-		return nil, argsEndPos, fmt.Errorf("no closing bracket for args list: %s", data)
-	}
-	// last arg
-	if len(curArg) > 0 {
-		args = append(args, string(curArg))
-	}
-	for i := range args {
-		args[i] = strings.TrimSpace(args[i])
-	}
-	return args, argsEndPos, nil
 }

--- a/cfg/substitution/substitution_test.go
+++ b/cfg/substitution/substitution_test.go
@@ -188,22 +188,22 @@ func TestParseFieldWithFilter(t *testing.T) {
 			wantErr:      true,
 		},
 		{
-			name:         "err_invalid_args_invalid_first_arg",
+			name:         "err_re_filter_invalid_args_invalid_first_arg",
 			substitution: `test ${field|re('(invalid)',-1,[1,],"|")} test2`,
 			wantErr:      true,
 		},
 		{
-			name:         "err_invalid_args_invalid_second_arg",
-			substitution: `test ${field|re('(invalid)',"abcd",[1,],"|")} test2`,
+			name:         "err_re_filter_invalid_args_invalid_second_arg",
+			substitution: `test ${field|re("(invalid)","abcd",[1,],"|")} test2`,
 			wantErr:      true,
 		},
 		{
-			name:         "err_invalid_args_invalid_third_arg",
+			name:         "err_re_filter_invalid_args_invalid_third_arg",
 			substitution: `test ${field|re("invalid",-1,[invalid],"|")} test2`,
 			wantErr:      true,
 		},
 		{
-			name:         "err_invalid_args_invalid_fourth_arg",
+			name:         "err_re_filter_invalid_args_invalid_fourth_arg",
 			substitution: `test ${field|re("(invalid)",-1,[1],'invalid')} test2`,
 			wantErr:      true,
 		},
@@ -231,6 +231,51 @@ func TestParseFieldWithFilter(t *testing.T) {
 			name:         "err_invalid_args_no_closing_quotes",
 			substitution: `test ${field|re("invalid", -1, [1,2], "|)} test2`,
 			wantErr:      true,
+		},
+		{
+			name:         "err_invalid_args_empty",
+			substitution: `test ${field|trim()} test2`,
+			wantErr:      true,
+		},
+		{
+			name:         "err_trim_filter_invalid_args_invalid_args",
+			substitution: `test ${field|trim("all",(invalid)} test2`,
+			wantErr:      true,
+		},
+		{
+			name:         "err_trim_filter_invalid_args_invalid_first_arg",
+			substitution: `test ${field|trim("invalid","\\n")} test2`,
+			wantErr:      true,
+		},
+		{
+			name:         "err_trim_filter_invalid_args_invalid_first_arg_2",
+			substitution: `test ${field|trim('invalid',"\\n")} test2`,
+			wantErr:      true,
+		},
+		{
+			name:         "err_trim_filter_invalid_args_invalid_second_arg",
+			substitution: `test ${field|trim("all",'invalid')} test2`,
+			wantErr:      true,
+		},
+		{
+			name:         "err_trim_filter_ok",
+			substitution: `test ${field|trim("all","\\n")} test2`,
+			data: [][]string{
+				{"test "},
+				{"field"},
+				{" test2"},
+			},
+			filters: [][][]any{
+				nil,
+				{
+					{
+						trimModeAll,
+						"\\n",
+					},
+				},
+				nil,
+			},
+			wantErr: false,
 		},
 	}
 

--- a/cfg/substitution/substitution_test.go
+++ b/cfg/substitution/substitution_test.go
@@ -270,22 +270,40 @@ func TestRegexFilterApply(t *testing.T) {
 		want         string
 	}{
 		{
-			name:         "ok_single_filter",
+			name:         "ok_single_re_filter",
 			substitution: `${field|re("(re\\d)",-1,[1],"|")}`,
 			data:         `this is some text re1 end`,
 			want:         "re1",
 		},
 		{
-			name:         "ok_two_filters",
+			name:         "ok_two_re_filters",
 			substitution: `${field|re("(.*)",-1,[1],"|")|re("(\\d\\.)",-1,[1],"|")}`,
 			data:         `1.2.3.4.5.`,
 			want:         "1.|2.|3.|4.|5.",
 		},
 		{
-			name:         "ok_single_filter",
+			name:         "ok_single_re_filter",
 			substitution: `${field|re("(re\\d)",2,[1],"|")}`,
 			data:         `this is some text re1 re2 re3 re4 end`,
 			want:         "re1|re2",
+		},
+		{
+			name:         "ok_single_trim_filter_trim_all",
+			substitution: `${field|trim("all","\\n")}`,
+			data:         `\n{"message":"test"}\n`,
+			want:         `{"message":"test"}`,
+		},
+		{
+			name:         "ok_single_trim_filter_trim_left",
+			substitution: `${field|trim("left","\\n")}`,
+			data:         `\n{"message":"test"}\n`,
+			want:         `{"message":"test"}\n`,
+		},
+		{
+			name:         "ok_single_trim_filter_trim_right",
+			substitution: `${field|trim("right","\\n")}`,
+			data:         `\n{"message":"test"}\n`,
+			want:         `\n{"message":"test"}`,
 		},
 	}
 	for _, tt := range tests {

--- a/cfg/substitution/trim_filter.go
+++ b/cfg/substitution/trim_filter.go
@@ -1,0 +1,97 @@
+package substitution
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+type trimMode int
+
+const (
+	trimModeAll trimMode = iota
+	trimModeLeft
+	trimModeRight
+)
+
+func trimModeFromString(s string) (trimMode, error) {
+	var mode trimMode
+	switch s {
+	case "all":
+		mode = trimModeAll
+	case "left":
+		mode = trimModeLeft
+	case "right":
+		mode = trimModeRight
+	default:
+		return mode, fmt.Errorf("invalid trim mode provided %q, allowed modes are \"all\", \"left\", \"right\"", s)
+	}
+	return mode, nil
+}
+
+type TrimFilter struct {
+	mode   trimMode
+	cutset string
+}
+
+func (t *TrimFilter) Apply(src []byte, _ []byte) []byte {
+	switch t.mode {
+	case trimModeLeft:
+		return bytes.TrimLeft(src, t.cutset)
+	case trimModeRight:
+		return bytes.TrimRight(src, t.cutset)
+	default:
+		return bytes.Trim(src, t.cutset)
+	}
+}
+
+func (t *TrimFilter) setBuffer(buf []byte) {}
+
+func (t *TrimFilter) compareArgs(args []any) error {
+	wantArgsCnt := 2
+	if len(args) != wantArgsCnt {
+		return fmt.Errorf("wrong trim filter amount of args, want=%d got=%d", wantArgsCnt, len(args))
+	}
+	wantMode := args[0].(trimMode)
+	gotMode := t.mode
+	if wantMode != gotMode {
+		return fmt.Errorf("wrong trim filter mode, want=%v got=%v", wantMode, gotMode)
+	}
+	wantCutset := args[1].(string)
+	gotCutset := t.cutset
+	if wantCutset != gotCutset {
+		return fmt.Errorf("wrong trim filter cutset, want=%q got=%q", wantCutset, gotCutset)
+	}
+	return nil
+}
+
+func parseTrimFilter(data string, offset int) (FieldFilter, int, error) {
+	expArgsCnt := 2
+	filterEndPos := -1
+	args, argsEndPos, err := parseFilterArgs(data[len(trimFilterPrefix):])
+	if err != nil {
+		return nil, filterEndPos, fmt.Errorf("failed to parse filter args: %w", err)
+	}
+	filterEndPos = argsEndPos + len(regexFilterPrefix) + offset
+	if len(args) != expArgsCnt {
+		return nil, filterEndPos, fmt.Errorf("invalid args for trim filter, exptected %d, got %d", expArgsCnt, len(args))
+	}
+	var mode trimMode
+	var modeStr string
+	var cutset string
+	if err := json.Unmarshal([]byte(args[0]), &modeStr); err != nil {
+		return nil, filterEndPos, fmt.Errorf("failed to parse trim filter mode: %w", err)
+	}
+	mode, err = trimModeFromString(modeStr)
+	if err != nil {
+		return nil, filterEndPos, fmt.Errorf("invalid trim mode provided %q, allowed modes are \"all\", \"left\", \"right\"", args[0])
+	}
+	if err := json.Unmarshal([]byte(args[1]), &cutset); err != nil {
+		return nil, filterEndPos, fmt.Errorf("failed to parse trim filter cutset: %w", err)
+	}
+	filter := &TrimFilter{
+		mode:   mode,
+		cutset: cutset,
+	}
+	return filter, filterEndPos, nil
+}

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -459,10 +459,14 @@ then the data extracted using first regular expression and formed into a new str
 and its result is formed into a value to be put in modified field.
 
 Currently available filters are:
+
 + `regex filter` - `re(regex string, limit int, groups []int, separator string)`, filters data using `regex`, extracts `limit` occurrences,
 takes regex groups listed in `groups` list, and if there are more than one extracted element concatenates result using `separator`.
 Negative value of `limit` means all occurrences are extracted, `limit` 0 means no occurrences are extracted, `limit` greater than 0 means
 at most `limit` occurrences are extracted.
+
++ `trim filter` - `trim(mode string, cutset string)`, trims data by the `cutset` substring. Available modes are `all` - trim both sides,
+`left` - trim only left, `right` - trim only right.
 
 Examples:
 
@@ -489,6 +493,14 @@ Data: `{"message:"service=service-test-1 exec took 200ms"}`
 Substitution: `took: ${message|re("service=([A-Za-z0-9_\-]+) exec took (\d+\.?\d*(?:ms|s|m|h))",-1,[2],",")}`
 
 Result: `{"message:"service=service-test-1 exec took 200ms","took":"200ms"}`
+
+Example #4:
+
+Data: `{"message:"{\"service\":\"service-test-1\",\"took\":\"200ms\"}\n"}`
+
+Substitution: `message: ${message|trim("right","\n")}`
+
+Result: `{"message:"{\"service\":\"service-test-1\",\"took\":\"200ms\"}"}`
 
 
 [More details...](plugin/action/modify/README.md)

--- a/plugin/action/README.md
+++ b/plugin/action/README.md
@@ -294,10 +294,14 @@ then the data extracted using first regular expression and formed into a new str
 and its result is formed into a value to be put in modified field.
 
 Currently available filters are:
+
 + `regex filter` - `re(regex string, limit int, groups []int, separator string)`, filters data using `regex`, extracts `limit` occurrences,
 takes regex groups listed in `groups` list, and if there are more than one extracted element concatenates result using `separator`.
 Negative value of `limit` means all occurrences are extracted, `limit` 0 means no occurrences are extracted, `limit` greater than 0 means
 at most `limit` occurrences are extracted.
+
++ `trim filter` - `trim(mode string, cutset string)`, trims data by the `cutset` substring. Available modes are `all` - trim both sides,
+`left` - trim only left, `right` - trim only right.
 
 Examples:
 
@@ -324,6 +328,14 @@ Data: `{"message:"service=service-test-1 exec took 200ms"}`
 Substitution: `took: ${message|re("service=([A-Za-z0-9_\-]+) exec took (\d+\.?\d*(?:ms|s|m|h))",-1,[2],",")}`
 
 Result: `{"message:"service=service-test-1 exec took 200ms","took":"200ms"}`
+
+Example #4:
+
+Data: `{"message:"{\"service\":\"service-test-1\",\"took\":\"200ms\"}\n"}`
+
+Substitution: `message: ${message|trim("right","\n")}`
+
+Result: `{"message:"{\"service\":\"service-test-1\",\"took\":\"200ms\"}"}`
 
 
 [More details...](plugin/action/modify/README.md)

--- a/plugin/action/modify/README.md
+++ b/plugin/action/modify/README.md
@@ -38,10 +38,14 @@ then the data extracted using first regular expression and formed into a new str
 and its result is formed into a value to be put in modified field.
 
 Currently available filters are:
+
 + `regex filter` - `re(regex string, limit int, groups []int, separator string)`, filters data using `regex`, extracts `limit` occurrences,
 takes regex groups listed in `groups` list, and if there are more than one extracted element concatenates result using `separator`.
 Negative value of `limit` means all occurrences are extracted, `limit` 0 means no occurrences are extracted, `limit` greater than 0 means
 at most `limit` occurrences are extracted.
+
++ `trim filter` - `trim(mode string, cutset string)`, trims data by the `cutset` substring. Available modes are `all` - trim both sides,
+`left` - trim only left, `right` - trim only right.
 
 Examples:
 
@@ -68,6 +72,14 @@ Data: `{"message:"service=service-test-1 exec took 200ms"}`
 Substitution: `took: ${message|re("service=([A-Za-z0-9_\-]+) exec took (\d+\.?\d*(?:ms|s|m|h))",-1,[2],",")}`
 
 Result: `{"message:"service=service-test-1 exec took 200ms","took":"200ms"}`
+
+Example #4:
+
+Data: `{"message:"{\"service\":\"service-test-1\",\"took\":\"200ms\"}\n"}`
+
+Substitution: `message: ${message|trim("right","\n")}`
+
+Result: `{"message:"{\"service\":\"service-test-1\",\"took\":\"200ms\"}"}`
 
 
 <br>*Generated using [__insane-doc__](https://github.com/vitkovskii/insane-doc)*

--- a/plugin/action/modify/modify.go
+++ b/plugin/action/modify/modify.go
@@ -50,10 +50,14 @@ then the data extracted using first regular expression and formed into a new str
 and its result is formed into a value to be put in modified field.
 
 Currently available filters are:
+
 + `regex filter` - `re(regex string, limit int, groups []int, separator string)`, filters data using `regex`, extracts `limit` occurrences,
 takes regex groups listed in `groups` list, and if there are more than one extracted element concatenates result using `separator`.
 Negative value of `limit` means all occurrences are extracted, `limit` 0 means no occurrences are extracted, `limit` greater than 0 means
 at most `limit` occurrences are extracted.
+
++ `trim filter` - `trim(mode string, cutset string)`, trims data by the `cutset` substring. Available modes are `all` - trim both sides,
+`left` - trim only left, `right` - trim only right.
 
 Examples:
 
@@ -80,6 +84,14 @@ Data: `{"message:"service=service-test-1 exec took 200ms"}`
 Substitution: `took: ${message|re("service=([A-Za-z0-9_\-]+) exec took (\d+\.?\d*(?:ms|s|m|h))",-1,[2],",")}`
 
 Result: `{"message:"service=service-test-1 exec took 200ms","took":"200ms"}`
+
+Example #4:
+
+Data: `{"message:"{\"service\":\"service-test-1\",\"took\":\"200ms\"}\n"}`
+
+Substitution: `message: ${message|trim("right","\n")}`
+
+Result: `{"message:"{\"service\":\"service-test-1\",\"took\":\"200ms\"}"}`
 
 }*/
 


### PR DESCRIPTION
# Description

Add trim filter to modify plugin. It has three modes: trim all, trim left and trim right. The filter accepts two arguments: mode and a cutset (substring to trim).

Fixes #598 