### PR TITLE
File input info

### DIFF
--- a/plugin/input/file/file.go
+++ b/plugin/input/file/file.go
@@ -179,6 +179,7 @@ func init() {
 		Factory: Factory,
 		Endpoints: map[string]func(http.ResponseWriter, *http.Request){
 			"reset": ResetterRegistryInstance.Reset,
+			"info":  InfoRegistryInstance.Info,
 		},
 	})
 }
@@ -206,6 +207,7 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.InputPluginPa
 	)
 
 	ResetterRegistryInstance.AddResetter(params.PipelineName, p)
+	InfoRegistryInstance.AddPlugin(p)
 
 	p.startWorkers()
 	p.jobProvider.start()

--- a/plugin/input/file/file.go
+++ b/plugin/input/file/file.go
@@ -209,7 +209,7 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.InputPluginPa
 	)
 
 	ResetterRegistryInstance.AddResetter(params.PipelineName, p)
-	InfoRegistryInstance.AddPlugin(p)
+	InfoRegistryInstance.AddPlugin(params.PipelineName, p)
 
 	p.startWorkers()
 	p.jobProvider.start()

--- a/plugin/input/file/file.go
+++ b/plugin/input/file/file.go
@@ -59,6 +59,7 @@ type Plugin struct {
 	alreadyWrittenEventsSkippedMetric prometheus.Counter
 	errorOpenFileMetric               prometheus.Counter
 	notifyChannelLengthMetric         prometheus.Gauge
+	numberOfCurrentJobsMetric         prometheus.Gauge
 }
 
 type persistenceMode int
@@ -202,6 +203,7 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.InputPluginPa
 			p.possibleOffsetCorruptionMetric,
 			p.errorOpenFileMetric,
 			p.notifyChannelLengthMetric,
+			p.numberOfCurrentJobsMetric,
 		),
 		p.logger,
 	)
@@ -218,6 +220,7 @@ func (p *Plugin) registerMetrics(ctl *metric.Ctl) {
 	p.alreadyWrittenEventsSkippedMetric = ctl.RegisterCounter("input_file_already_written_event_skipped_total", "Total number of skipped events that was already written")
 	p.errorOpenFileMetric = ctl.RegisterCounter("input_file_open_error_total", "Total number of file opening errors")
 	p.notifyChannelLengthMetric = ctl.RegisterGauge("input_file_watcher_channel_length", "Number of unprocessed notify events")
+	p.numberOfCurrentJobsMetric = ctl.RegisterGauge("input_file_provider_jobs_length", "Number of current jobs")
 }
 
 func (p *Plugin) startWorkers() {

--- a/plugin/input/file/info.go
+++ b/plugin/input/file/info.go
@@ -1,0 +1,40 @@
+package file
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/ozontech/file.d/logger"
+)
+
+var InfoRegistryInstance = &InfoRegistry{}
+
+type InfoRegistry struct {
+	plug *Plugin
+}
+
+func (ir *InfoRegistry) AddPlugin(plug *Plugin) {
+	ir.plug = plug
+}
+
+func (ir *InfoRegistry) Info(w http.ResponseWriter, _ *http.Request) {
+	_, _ = w.Write([]byte("<html><body><pre><p>"))
+
+	out := logger.Cond(len(ir.plug.jobProvider.jobs) == 0, logger.Header("no jobs"), func() string {
+		o := logger.Header("jobs")
+		ir.plug.jobProvider.jobsMu.RLock()
+		for s, source := range ir.plug.jobProvider.jobs {
+			o += fmt.Sprintf(
+				"source_id: %d, filename: %s, inode: %d, offset: %d\n",
+				s, source.filename,
+				source.inode, source.curOffset,
+			)
+		}
+		ir.plug.jobProvider.jobsMu.RUnlock()
+		return o
+	})
+
+	_, _ = w.Write([]byte(out))
+
+	_, _ = w.Write([]byte("</p></pre></body></html>"))
+}

--- a/plugin/input/file/info.go
+++ b/plugin/input/file/info.go
@@ -20,7 +20,7 @@ func (ir *InfoRegistry) AddPlugin(plug *Plugin) {
 func (ir *InfoRegistry) Info(w http.ResponseWriter, _ *http.Request) {
 	_, _ = w.Write([]byte("<html><body><pre><p>"))
 
-	out := logger.Cond(len(ir.plug.jobProvider.jobs) == 0, logger.Header("no jobs"), func() string {
+	jobsInfo := logger.Cond(len(ir.plug.jobProvider.jobs) == 0, logger.Header("no jobs"), func() string {
 		o := logger.Header("jobs")
 		ir.plug.jobProvider.jobsMu.RLock()
 		for s, source := range ir.plug.jobProvider.jobs {
@@ -34,7 +34,14 @@ func (ir *InfoRegistry) Info(w http.ResponseWriter, _ *http.Request) {
 		return o
 	})
 
-	_, _ = w.Write([]byte(out))
+	_, _ = w.Write([]byte(jobsInfo))
+
+	watcherInfo := logger.Header("watch_dirs")
+	watcherInfo += fmt.Sprintf(
+		"%s\n",
+		ir.plug.jobProvider.watcher.path,
+	)
+	_, _ = w.Write([]byte(watcherInfo))
 
 	_, _ = w.Write([]byte("</p></pre></body></html>"))
 }

--- a/plugin/input/file/worker_test.go
+++ b/plugin/input/file/worker_test.go
@@ -97,6 +97,7 @@ func TestWorkerWork(t *testing.T) {
 				ctl.RegisterCounter("worker1", "help_test"),
 				ctl.RegisterCounter("worker2", "help_test"),
 				ctl.RegisterGauge("worker3", "help_test"),
+				ctl.RegisterGauge("worker4", "help_test"),
 			)
 			jp := NewJobProvider(&Config{}, metrics, &zap.SugaredLogger{})
 			jp.jobsChan = make(chan *Job, 2)
@@ -230,6 +231,7 @@ func TestWorkerWorkMultiData(t *testing.T) {
 				ctl.RegisterCounter("worker1", "help_test"),
 				ctl.RegisterCounter("worker2", "help_test"),
 				ctl.RegisterGauge("worker3", "help_test"),
+				ctl.RegisterGauge("worker4", "help_test"),
 			)
 			jp := NewJobProvider(&Config{}, metrics, &zap.SugaredLogger{})
 			jp.jobsChan = make(chan *Job, 2)


### PR DESCRIPTION
# Description

Add some diagnostic information for file input plugin

- add info url ```/pipelines/*/0/info``` with active sources (source_id, filename, inode and offset)
- add metric input_file_provider_jobs_length (try to catch reach limit of max open files and loose of sources)