### PR TITLE
fix(decoder): handling not found index for postgres logs

### DIFF
--- a/decoder/postgres.go
+++ b/decoder/postgres.go
@@ -66,7 +66,7 @@ func DecodePostgres(event *insaneJSON.Root, data []byte) error {
 
 	// client
 	openPos := bytes.IndexByte(data, credentialValueDelimiter)
-	if pos < 0 {
+	if openPos < 0 {
 		return fmt.Errorf("client start is not found")
 	}
 
@@ -80,7 +80,7 @@ func DecodePostgres(event *insaneJSON.Root, data []byte) error {
 
 	// db
 	openPos = bytes.IndexByte(data, credentialValueDelimiter)
-	if pos < 0 {
+	if openPos < 0 {
 		return fmt.Errorf("db start is not found")
 	}
 
@@ -94,7 +94,7 @@ func DecodePostgres(event *insaneJSON.Root, data []byte) error {
 
 	// user
 	openPos = bytes.IndexByte(data, credentialValueDelimiter)
-	if pos < 0 {
+	if openPos < 0 {
 		return fmt.Errorf("user start is not found")
 	}
 


### PR DESCRIPTION
# Description

Fixed the processing of an undiscovered index in the PostgreSQL decoder, which in my opinion is important for predictable behavior