### PR TITLE
use meta in antispam_field

### DIFF
--- a/fd/util.go
+++ b/fd/util.go
@@ -18,6 +18,7 @@ import (
 func extractPipelineParams(settings *simplejson.Json) *pipeline.Settings {
 	capacity := pipeline.DefaultCapacity
 	antispamThreshold := 0
+	antispamField := ""
 	var antispamExceptions matchrule.RuleSets
 	avgInputEventSize := pipeline.DefaultAvgInputEventSize
 	maxInputEventSize := pipeline.DefaultMaxInputEventSize
@@ -82,6 +83,8 @@ func extractPipelineParams(settings *simplejson.Json) *pipeline.Settings {
 			antispamThreshold = 0
 		}
 
+		antispamField = settings.Get("antispam_field").MustString()
+
 		var err error
 		antispamExceptions, err = extractExceptions(settings)
 		if err != nil {
@@ -108,6 +111,7 @@ func extractPipelineParams(settings *simplejson.Json) *pipeline.Settings {
 		AvgEventSize:        avgInputEventSize,
 		MaxEventSize:        maxInputEventSize,
 		AntispamThreshold:   antispamThreshold,
+		AntispamField:       antispamField,
 		AntispamExceptions:  antispamExceptions,
 		MaintenanceInterval: maintenanceInterval,
 		EventTimeout:        eventTimeout,

--- a/pipeline/antispam/antispammer.go
+++ b/pipeline/antispam/antispammer.go
@@ -48,7 +48,7 @@ type Options struct {
 	MetricsController *metric.Ctl
 }
 
-func NewAntispammer(o Options) *Antispammer {
+func NewAntispammer(o *Options) *Antispammer {
 	if o.Threshold > 0 {
 		o.Logger.Info("antispam enabled",
 			zap.Int("threshold", o.Threshold),

--- a/pipeline/antispam/antispammer.go
+++ b/pipeline/antispam/antispammer.go
@@ -135,7 +135,11 @@ func (a *Antispammer) IsSpam(id any, name string, isNewSource bool, event []byte
 		a.activeMetric.Set(1)
 		a.banMetric.WithLabelValues(name).Inc()
 		a.logger.Warn("source has been banned",
-			zap.Any("id", id), zap.String("name", name))
+			zap.Any("id", id), zap.String("name", name),
+			zap.Time("time_event", timeEvent), zap.Int64("diff_nsec", diff),
+			zap.Int64("maintenance_nsec", a.maintenanceInterval.Nanoseconds()),
+			zap.Int32("counter", src.counter.Load()),
+		)
 	}
 
 	return x >= int32(a.threshold)
@@ -191,7 +195,7 @@ func (a *Antispammer) Dump() string {
 		for s, source := range a.sources {
 			value := source.counter.Load()
 			if int(value) >= a.threshold {
-				o += fmt.Sprintf("source_id: %v, source_name: %s, events_counter: %d\n", s, source.name, value)
+				o += fmt.Sprintf("source_id: %v, source_name: %s, counter: %d\n", s, source.name, value)
 			}
 		}
 		a.mu.RUnlock()

--- a/pipeline/antispam/antispammer_test.go
+++ b/pipeline/antispam/antispammer_test.go
@@ -15,7 +15,7 @@ func TestAntispam(t *testing.T) {
 
 	threshold := 5
 	unbanIterations := 2
-	antispamer := NewAntispammer(Options{
+	antispamer := NewAntispammer(&Options{
 		MaintenanceInterval: time.Second * 1,
 		Threshold:           threshold,
 		UnbanIterations:     unbanIterations,

--- a/pipeline/antispam/antispammer_test.go
+++ b/pipeline/antispam/antispammer_test.go
@@ -15,30 +15,61 @@ func TestAntispam(t *testing.T) {
 
 	threshold := 5
 	unbanIterations := 2
+	maintenanceInterval := time.Second * 1
 	antispamer := NewAntispammer(&Options{
-		MaintenanceInterval: time.Second * 1,
+		MaintenanceInterval: maintenanceInterval,
 		Threshold:           threshold,
 		UnbanIterations:     unbanIterations,
 		Logger:              logger.Instance.Named("antispam").Desugar(),
 		MetricsController:   metric.NewCtl("test", prometheus.NewRegistry()),
 	})
 
-	checkSpam := func() bool {
-		return antispamer.IsSpam(1, "test", false, []byte(`{}`))
+	startTime := time.Now()
+	checkSpam := func(i int) bool {
+		eventTime := startTime.Add(time.Duration(i) * maintenanceInterval / 2)
+		return antispamer.IsSpam(1, "test", false, []byte(`{}`), eventTime)
 	}
 
-	for i := 0; i < threshold-1; i++ {
-		result := checkSpam()
+	for i := 1; i < threshold; i++ {
+		result := checkSpam(i)
 		r.False(result)
 	}
 
-	result := checkSpam()
-	r.True(result)
-
-	for i := 0; i <= unbanIterations; i++ {
+	for i := 0; i <= unbanIterations-1; i++ {
+		result := checkSpam(threshold + i)
+		r.True(result)
 		antispamer.Maintenance()
 	}
 
-	result = checkSpam()
+	result := checkSpam(threshold + 1)
+	r.False(result)
+}
+
+func TestAntispamAfterRestart(t *testing.T) {
+	r := require.New(t)
+
+	threshold := 5
+	unbanIterations := 2
+	maintenanceInterval := time.Second * 1
+	antispamer := NewAntispammer(&Options{
+		MaintenanceInterval: maintenanceInterval,
+		Threshold:           threshold,
+		UnbanIterations:     unbanIterations,
+		Logger:              logger.Instance.Named("antispam").Desugar(),
+		MetricsController:   metric.NewCtl("test", prometheus.NewRegistry()),
+	})
+
+	startTime := time.Now()
+	checkSpam := func(i int) bool {
+		eventTime := startTime.Add(time.Duration(i) * maintenanceInterval)
+		return antispamer.IsSpam(1, "test", false, []byte(`{}`), eventTime)
+	}
+
+	for i := 1; i < threshold; i++ {
+		result := checkSpam(i)
+		r.False(result)
+	}
+
+	result := checkSpam(threshold)
 	r.False(result)
 }

--- a/pipeline/antispam/antispammer_test.go
+++ b/pipeline/antispam/antispammer_test.go
@@ -16,12 +16,14 @@ func TestAntispam(t *testing.T) {
 	threshold := 5
 	unbanIterations := 2
 	maintenanceInterval := time.Second * 1
+	holder := metric.NewHolder(time.Minute)
 	antispamer := NewAntispammer(&Options{
 		MaintenanceInterval: maintenanceInterval,
 		Threshold:           threshold,
 		UnbanIterations:     unbanIterations,
 		Logger:              logger.Instance.Named("antispam").Desugar(),
 		MetricsController:   metric.NewCtl("test", prometheus.NewRegistry()),
+		MetricHolder:        holder,
 	})
 
 	startTime := time.Now()
@@ -51,12 +53,14 @@ func TestAntispamAfterRestart(t *testing.T) {
 	threshold := 5
 	unbanIterations := 2
 	maintenanceInterval := time.Second * 1
+	holder := metric.NewHolder(time.Minute)
 	antispamer := NewAntispammer(&Options{
 		MaintenanceInterval: maintenanceInterval,
 		Threshold:           threshold,
 		UnbanIterations:     unbanIterations,
 		Logger:              logger.Instance.Named("antispam").Desugar(),
 		MetricsController:   metric.NewCtl("test", prometheus.NewRegistry()),
+		MetricHolder:        holder,
 	})
 
 	startTime := time.Now()

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -412,7 +412,15 @@ func (p *Pipeline) In(sourceID SourceID, sourceName string, offset int64, bytes 
 				p.Error(fmt.Sprintf("antispam_field %s does not exists in meta", p.settings.AntispamField))
 			}
 		}
-		isSpam := p.antispamer.IsSpam(checkSourceID, checkSourceName, isNewSource, bytes)
+
+		var eventTime time.Time
+		if len(row.Time) > 0 {
+			eventTime, err = time.Parse("2006-01-02T15:04:05.999999999Z", string(row.Time))
+			if err != nil {
+				p.Error(fmt.Sprintf("cannot parse raw time %s: %v", row.Time, err))
+			}
+		}
+		isSpam := p.antispamer.IsSpam(checkSourceID, checkSourceName, isNewSource, bytes, eventTime)
 		if isSpam {
 			return EventSeqIDError
 		}

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -167,7 +167,7 @@ func New(name string, settings *Settings, registry *prometheus.Registry) *Pipeli
 		metricHolder: metric.NewHolder(settings.MetricHoldDuration),
 		streamer:     newStreamer(settings.EventTimeout),
 		eventPool:    newEventPool(settings.Capacity, settings.AvgEventSize),
-		antispamer: antispam.NewAntispammer(antispam.Options{
+		antispamer: antispam.NewAntispammer(&antispam.Options{
 			MaintenanceInterval: settings.MaintenanceInterval,
 			Threshold:           settings.AntispamThreshold,
 			Field:               settings.AntispamField,
@@ -400,7 +400,7 @@ func (p *Pipeline) In(sourceID SourceID, sourceName string, offset int64, bytes 
 	if !row.IsPartial && p.settings.AntispamThreshold > 0 {
 		var checkSourceID any
 		var checkSourceName string
-		if len(p.settings.AntispamField) == 0 {
+		if p.settings.AntispamField == "" {
 			checkSourceID = uint64(sourceID)
 			checkSourceName = sourceName
 		} else {

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -410,6 +410,8 @@ func (p *Pipeline) In(sourceID SourceID, sourceName string, offset int64, bytes 
 				isNewSource = false
 			} else {
 				p.Error(fmt.Sprintf("antispam_field %s does not exists in meta", p.settings.AntispamField))
+				checkSourceID = uint64(sourceID)
+				checkSourceName = sourceName
 			}
 		}
 

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -148,6 +148,7 @@ func New(name string, settings *Settings, registry *prometheus.Registry) *Pipeli
 	metricCtl := metric.NewCtl("pipeline_"+name, registry)
 
 	lg := logger.Instance.Named(name).Desugar()
+	metricHolder := metric.NewHolder(settings.MetricHoldDuration)
 
 	pipeline := &Pipeline{
 		Name:           name,
@@ -164,7 +165,7 @@ func New(name string, settings *Settings, registry *prometheus.Registry) *Pipeli
 			m:  make(map[string]*actionMetric),
 			mu: new(sync.RWMutex),
 		},
-		metricHolder: metric.NewHolder(settings.MetricHoldDuration),
+		metricHolder: metricHolder,
 		streamer:     newStreamer(settings.EventTimeout),
 		eventPool:    newEventPool(settings.Capacity, settings.AvgEventSize),
 		antispamer: antispam.NewAntispammer(&antispam.Options{
@@ -174,6 +175,7 @@ func New(name string, settings *Settings, registry *prometheus.Registry) *Pipeli
 			UnbanIterations:     antispamUnbanIterations,
 			Logger:              lg.Named("antispam"),
 			MetricsController:   metricCtl,
+			MetricHolder:        metricHolder,
 			Exceptions:          settings.AntispamExceptions,
 		}),
 

--- a/plugin/input/file/README.idoc.md
+++ b/plugin/input/file/README.idoc.md
@@ -3,3 +3,12 @@
 
 ### Config params
 @config-params|description
+
+### Meta params
+**`filename`** 
+
+**`symlink`** 
+
+**`inode`** 
+
+**`offset`** 

--- a/plugin/input/file/README.md
+++ b/plugin/input/file/README.md
@@ -136,5 +136,25 @@ It turns on watching for file modifications. Turning it on cause more CPU work, 
 
 <br>
 
+**`meta`** *`cfg.MetaTemplates`* 
+
+Meta params
+
+Add meta information to an event (look at Meta params)
+Use [go-template](https://pkg.go.dev/text/template) syntax
+
+Example: ```filename: '{{ .filename }}'```
+
+<br>
+
+
+### Meta params
+**`filename`** 
+
+**`symlink`** 
+
+**`inode`** 
+
+**`offset`** 
 
 <br>*Generated using [__insane-doc__](https://github.com/vitkovskii/insane-doc)*

--- a/plugin/input/file/provider.go
+++ b/plugin/input/file/provider.go
@@ -434,13 +434,13 @@ func (jp *jobProvider) initJobOffset(operation offsetsOp, job *Job) {
 
 		job.offsets = sliceFromMap(offsets.streams)
 		// find min Offset to start read from it
-		minOffset := int64(math.MaxInt64)
+		maxOffset := int64(0)
 		for _, offset := range offsets.streams {
-			if offset < minOffset {
-				minOffset = offset
+			if offset > maxOffset {
+				maxOffset = offset
 			}
 		}
-		job.seek(minOffset, io.SeekStart, "job initialization")
+		job.seek(maxOffset, io.SeekStart, "job initialization")
 	default:
 		jp.logger.Panicf("unknown offsets op: %d", jp.config.OffsetsOp_)
 	}

--- a/plugin/input/file/provider.go
+++ b/plugin/input/file/provider.go
@@ -434,13 +434,13 @@ func (jp *jobProvider) initJobOffset(operation offsetsOp, job *Job) {
 
 		job.offsets = sliceFromMap(offsets.streams)
 		// find min Offset to start read from it
-		maxOffset := int64(0)
+		minOffset := int64(math.MaxInt64)
 		for _, offset := range offsets.streams {
-			if offset > maxOffset {
-				maxOffset = offset
+			if offset < minOffset {
+				minOffset = offset
 			}
 		}
-		job.seek(maxOffset, io.SeekStart, "job initialization")
+		job.seek(minOffset, io.SeekStart, "job initialization")
 	default:
 		jp.logger.Panicf("unknown offsets op: %d", jp.config.OffsetsOp_)
 	}


### PR DESCRIPTION
## Description

### Use value from in antispam

```yaml
pipelines:
  http:
    input:
      type: http
      address: ":9400"
      meta:
        remote_addr: "{{ .remote_addr }}"
    settings:
      antispam_threshold: 10
      antispam_field: remote_addr
```

### meta from file input plugin

**`filename`** 

**`symlink`** 

**`inode`** 

**`offset`** 

### antispam_banned metric with antispam_field label

### pass eventTime (decoded from cri format) to antispam

### dont count event in antispam if period more than maintenance period