### PR TITLE
check stream name in cri decoder

### DIFF
--- a/decoder/cri.go
+++ b/decoder/cri.go
@@ -34,7 +34,13 @@ func DecodeCRI(data []byte) (row CRIRow, _ error) {
 		return row, fmt.Errorf("stream type is not found")
 	}
 
-	row.Stream = data[:pos]
+	stream := data[:pos]
+	// stderr or stdout
+	if len(stream) != 6 {
+		return row, fmt.Errorf("stream is unknown")
+	}
+	row.Stream = stream
+
 	data = data[pos+1:]
 
 	// tags

--- a/decoder/cri_test.go
+++ b/decoder/cri_test.go
@@ -31,3 +31,9 @@ func TestCRIError(t *testing.T) {
 
 	assert.Error(t, err, "there must be an error")
 }
+
+func TestCRIErrorSplittedLines(t *testing.T) {
+	_, err := DecodeCRI([]byte("2024-05-22T09:51:04.025764351Z s2024-05-22T10:15:04.129321194Z stderr F 2024/05/22 10:15:04 start prepraring file\n"))
+
+	assert.Error(t, err, "there must be an error")
+}


### PR DESCRIPTION
Sometimes we have broken logs in k8s:

```
2024-05-22T09:51:04.025764351Z s2024-05-22T10:15:04.129321194Z stderr F 2024/05/22 10:15:04 start prepraring file\n
```

According https://github.com/kubernetes/design-proposals-archive/blob/main/node/kubelet-cri-logging.md we have only two types of streams (stderr and stdout)