### PR TITLE
Fix throttle decode value from redis

### DIFF
--- a/plugin/action/throttle/redis_limiter.go
+++ b/plugin/action/throttle/redis_limiter.go
@@ -207,16 +207,18 @@ func (l *redisLimiter) updateLimiterValues(maxID, bucketIdx int, totalLimiterVal
 }
 
 func getLimitValFromJson(data []byte, valField string) (int64, error) {
-	var m map[string]json.Number
+	var limit int64
+	var err error
+	var m map[string]json.RawMessage
 	reader := bytes.NewReader(data)
-	if err := json.NewDecoder(reader).Decode(&m); err != nil {
-		return 0, fmt.Errorf("failed to unmarshal map: %w", err)
+	if err = json.NewDecoder(reader).Decode(&m); err != nil {
+		return limit, fmt.Errorf("failed to unmarshal map: %w", err)
 	}
 	limitVal, has := m[valField]
 	if !has {
-		return 0, fmt.Errorf("no %q key in map", valField)
+		return limit, fmt.Errorf("no %q key in map", valField)
 	}
-	return limitVal.Int64()
+	return json.Number(bytes.Trim(limitVal, `"`)).Int64()
 }
 
 // updateKeyLimit reads key limit from redis and updates current limit.

--- a/plugin/action/throttle/redis_limiter.go
+++ b/plugin/action/throttle/redis_limiter.go
@@ -207,16 +207,14 @@ func (l *redisLimiter) updateLimiterValues(maxID, bucketIdx int, totalLimiterVal
 }
 
 func getLimitValFromJson(data []byte, valField string) (int64, error) {
-	var limit int64
-	var err error
 	var m map[string]json.RawMessage
 	reader := bytes.NewReader(data)
-	if err = json.NewDecoder(reader).Decode(&m); err != nil {
-		return limit, fmt.Errorf("failed to unmarshal map: %w", err)
+	if err := json.NewDecoder(reader).Decode(&m); err != nil {
+		return 0, fmt.Errorf("failed to unmarshal map: %w", err)
 	}
 	limitVal, has := m[valField]
 	if !has {
-		return limit, fmt.Errorf("no %q key in map", valField)
+		return 0, fmt.Errorf("no %q key in map", valField)
 	}
 	return json.Number(bytes.Trim(limitVal, `"`)).Int64()
 }

--- a/plugin/action/throttle/redis_limiter_test.go
+++ b/plugin/action/throttle/redis_limiter_test.go
@@ -368,6 +368,15 @@ func Test_getLimitValFromJson(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "ok_with_object",
+			args: args{
+				data:     []byte(`{"limit_key":"3000","some_obj":{"field":"key"}}`),
+				valField: "limit_key",
+			},
+			want:    3000,
+			wantErr: false,
+		},
+		{
 			name: "unmarshal_error",
 			args: args{
 				data:     []byte(`"3000"`),


### PR DESCRIPTION
Fix decode value from redis when value contains more than just numbers.
See `Test_getLimitValFromJson.ok_with_object` for details.