### PR TITLE
Add copy fields feat to output splunk plugin

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,8 @@ linters-settings:
   govet:
     enable:
       - composites
+    disable:
+      - printf
   dupl:
     threshold: 120
   goconst:

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -852,6 +852,52 @@ pipelines:
 ## splunk
 It sends events to splunk.
 
+By default it only stores original event under the "event" key according to the Splunk output format.
+
+If other fields are required it is possible to copy fields values from the original event to the other
+fields relative to the output json. Copies are not allowed directly to the root of output event or
+"event" field and any of its subfields.
+
+For example, timestamps and service name can be copied to provide additional meta data to the Splunk:
+
+```yaml
+copy_fields:
+  - from: ts
+  	to: time
+  - from: service
+  	to: fields.service_name
+```
+
+Here the plugin will lookup for "ts" and "service" fields in the original event and if they are present
+they will be copied to the output json starting on the same level as the "event" key. If the field is not
+found in the original event plugin will not populate new field in output json.
+
+In:
+
+```json
+{
+  "ts":"1723651045",
+  "service":"some-service",
+  "message":"something happened"
+}
+```
+
+Out:
+
+```json
+{
+  "event": {
+    "ts":"1723651045",
+    "service":"some-service",
+    "message":"something happened"
+  },
+  "time": "1723651045",
+  "fields": {
+    "service_name": "some-service"
+  }
+}
+```
+
 [More details...](plugin/output/splunk/README.md)
 ## stdout
 It writes events to stdout(also known as console).

--- a/plugin/output/README.md
+++ b/plugin/output/README.md
@@ -129,6 +129,52 @@ pipelines:
 ## splunk
 It sends events to splunk.
 
+By default it only stores original event under the "event" key according to the Splunk output format.
+
+If other fields are required it is possible to copy fields values from the original event to the other
+fields relative to the output json. Copies are not allowed directly to the root of output event or
+"event" field and any of its subfields.
+
+For example, timestamps and service name can be copied to provide additional meta data to the Splunk:
+
+```yaml
+copy_fields:
+  - from: ts
+  	to: time
+  - from: service
+  	to: fields.service_name
+```
+
+Here the plugin will lookup for "ts" and "service" fields in the original event and if they are present
+they will be copied to the output json starting on the same level as the "event" key. If the field is not
+found in the original event plugin will not populate new field in output json.
+
+In:
+
+```json
+{
+  "ts":"1723651045",
+  "service":"some-service",
+  "message":"something happened"
+}
+```
+
+Out:
+
+```json
+{
+  "event": {
+    "ts":"1723651045",
+    "service":"some-service",
+    "message":"something happened"
+  },
+  "time": "1723651045",
+  "fields": {
+    "service_name": "some-service"
+  }
+}
+```
+
 [More details...](plugin/output/splunk/README.md)
 ## stdout
 It writes events to stdout(also known as console).

--- a/plugin/output/splunk/README.md
+++ b/plugin/output/splunk/README.md
@@ -1,6 +1,52 @@
 # splunk HTTP Event Collector output
 It sends events to splunk.
 
+By default it only stores original event under the "event" key according to the Splunk output format.
+
+If other fields are required it is possible to copy fields values from the original event to the other
+fields relative to the output json. Copies are not allowed directly to the root of output event or
+"event" field and any of its subfields.
+
+For example, timestamps and service name can be copied to provide additional meta data to the Splunk:
+
+```yaml
+copy_fields:
+  - from: ts
+  	to: time
+  - from: service
+  	to: fields.service_name
+```
+
+Here the plugin will lookup for "ts" and "service" fields in the original event and if they are present
+they will be copied to the output json starting on the same level as the "event" key. If the field is not
+found in the original event plugin will not populate new field in output json.
+
+In:
+
+```json
+{
+  "ts":"1723651045",
+  "service":"some-service",
+  "message":"something happened"
+}
+```
+
+Out:
+
+```json
+{
+  "event": {
+    "ts":"1723651045",
+    "service":"some-service",
+    "message":"something happened"
+  },
+  "time": "1723651045",
+  "fields": {
+    "service_name": "some-service"
+  }
+}
+```
+
 ### Config params
 **`endpoint`** *`string`* *`required`* 
 
@@ -80,6 +126,16 @@ Retention milliseconds for retry to DB.
 **`retention_exponentially_multiplier`** *`int`* *`default=2`* 
 
 Multiplier for exponential increase of retention between retries
+
+<br>
+
+**`copy_fields`** *`[]CopyField`* 
+
+List of field paths copy `from` field in original event `to` field in output json.
+To fields paths are relative to output json - one level higher since original
+event is stored under the "event" key. Supports nested fields in both from and to.
+Supports copying whole original event, but does not allow to copy directly to the output root
+or the "event" key with any of its subkeys.
 
 <br>
 

--- a/plugin/output/splunk/splunk_test.go
+++ b/plugin/output/splunk/splunk_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/ozontech/file.d/cfg"
 	"github.com/ozontech/file.d/pipeline"
 	"github.com/stretchr/testify/assert"
 	"github.com/valyala/fasthttp"
@@ -181,6 +182,100 @@ func TestParseSplunkError(t *testing.T) {
 
 			err := parseSplunkError([]byte(tt.data))
 			assert.Equal(t, tt.wantErr, err != nil)
+		})
+	}
+}
+
+func TestCopyFields(t *testing.T) {
+	suites := []struct {
+		name       string
+		copyFields []copyFieldPaths
+		input      string
+		expected   string
+	}{
+		{
+			`no_copy_fields`,
+			nil,
+			`{"msg":"AAAA","some_field":"BBBB"}`,
+			`{"event":{"msg":"AAAA","some_field":"BBBB"}}`,
+		},
+		{
+			`copy_absent_field`,
+			[]copyFieldPaths{{cfg.ParseFieldSelector("ts"), cfg.ParseFieldSelector("time")}},
+			`{"msg":"AAAA","some_field":"BBBB"}`,
+			`{"event":{"msg":"AAAA","some_field":"BBBB"}}`,
+		},
+		{
+			`copy_single_non_nested_field`,
+			[]copyFieldPaths{{cfg.ParseFieldSelector("ts"), cfg.ParseFieldSelector("time")}},
+			`{"msg":"AAAA","some_field":"BBBB","ts":"1723651045"}`,
+			`{"event":{"msg":"AAAA","some_field":"BBBB","ts":"1723651045"},"time":"1723651045"}`,
+		},
+		{
+			`copy_single_field_to_nested_field`,
+			[]copyFieldPaths{{cfg.ParseFieldSelector("service"), cfg.ParseFieldSelector("fields.service_name")}},
+			`{"msg":"AAAA","some_field":"BBBB","service":"test-svc"}`,
+			`{"event":{"msg":"AAAA","some_field":"BBBB","service":"test-svc"},"fields":{"service_name":"test-svc"}}`,
+		},
+		{
+			`copy_two_fields`,
+			[]copyFieldPaths{
+				{cfg.ParseFieldSelector("ts"), cfg.ParseFieldSelector("time")},
+				{cfg.ParseFieldSelector("service"), cfg.ParseFieldSelector("fields.service_name")},
+			},
+			`{"msg":"AAAA","some_field":"BBBB","ts":"1723651045","service":"test-svc"}`,
+			`{"event":{"msg":"AAAA","some_field":"BBBB","ts":"1723651045","service":"test-svc"},"time":"1723651045","fields":{"service_name":"test-svc"}}`,
+		},
+		{
+			`copy_root`,
+			[]copyFieldPaths{
+				{cfg.ParseFieldSelector(""), cfg.ParseFieldSelector("copy")},
+			},
+			`{"msg":"AAAA","some_field":"BBBB"}`,
+			`{"event":{"msg":"AAAA","some_field":"BBBB"},"copy":{"msg":"AAAA","some_field":"BBBB"}}`,
+		},
+	}
+
+	for _, tt := range suites {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			input, err := insaneJSON.DecodeBytes([]byte(tt.input))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer insaneJSON.Release(input)
+
+			var response []byte
+			testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+				response, err = io.ReadAll(req.Body)
+				if err != nil {
+					t.Fatal(err)
+				}
+				res.WriteHeader(http.StatusOK)
+				_, _ = res.Write([]byte(`{"code":0}`))
+			}))
+			defer testServer.Close()
+
+			plugin := Plugin{
+				config: &Config{
+					Endpoint: testServer.URL,
+				},
+				copyFieldsPaths: tt.copyFields,
+				logger:          zap.NewExample().Sugar(),
+			}
+			plugin.prepareClient()
+
+			batch := pipeline.NewPreparedBatch([]*pipeline.Event{
+				{Root: input},
+				{Root: input},
+			})
+
+			data := pipeline.WorkerData(nil)
+			_ = plugin.out(&data, batch)
+
+			assert.Equal(t, tt.expected+tt.expected, string(response))
 		})
 	}
 }


### PR DESCRIPTION
# Description

This pr adds "copy_fields" param to the output splunk plugin. It is a map of strings to strings. Keys and values are json paths, keys are paths in the original event, values are paths in the output json. This feature allows copying data from the original event to the additional meta data provided for splunk like timestamp in "time" or other data in "fields". Overwriting "event" and any of its subfields is not allowed to preserve original event as is.

Fixes #667 