### PR TITLE
Fix allocations in bytes_len_cmp

### DIFF
--- a/pipeline/doif/do_if_test.go
+++ b/pipeline/doif/do_if_test.go
@@ -1079,7 +1079,10 @@ const userInfoRawJSON = `
 {
 	"name": "jack",
 	"age": 120,
-	"hobbies": ["football", "diving"]
+	"hobbies": ["football", "diving"],
+	"obj": {
+		"a": "b"
+	}
 }`
 
 func dryJSON(rawJSON string) string {


### PR DESCRIPTION
# Description

Replaces encoding object or array json node to counting bytes length recursively.

There can be a slight divergence in case when field names have escaping `\"` since it will be considered as one symbol instead of two because of to process object fields insaneJSON AsField is called and it always escapes field names. But there is a huge advantage in memory consumption in this fix and such difference is negligible.

Also there might be divergence when byte_len is computed after string field was unescaped in some action plugin and it should be considered when using this comparison condition. 

Fixes #671