### PR TITLE
Add do_if check_type op

### DIFF
--- a/fd/util.go
+++ b/fd/util.go
@@ -221,10 +221,14 @@ var (
 	doIfTimestampCmpOpNodes = map[string]struct{}{
 		"ts_cmp": {},
 	}
+	checkTypeOpName = "check_type"
 )
 
 func extractFieldOpVals(jsonNode *simplejson.Json) [][]byte {
-	values := jsonNode.Get("values")
+	values, has := jsonNode.CheckGet("values")
+	if !has {
+		return nil
+	}
 	vals := make([][]byte, 0)
 	iFaceVal := values.Interface()
 	if iFaceVal == nil {
@@ -400,6 +404,19 @@ func extractTsCmpOpNode(_ string, jsonNode *simplejson.Json) (doif.Node, error) 
 	return doif.NewTsCmpOpNode(fieldPath, format, cmpOp, cmpMode, cmpValue, cmpValueShift, updateInterval)
 }
 
+func extractCheckTypeOpNode(_ string, jsonNode *simplejson.Json) (doif.Node, error) {
+	fieldPath, err := requiredString(jsonNode, "field")
+	if err != nil {
+		return nil, err
+	}
+	vals := extractFieldOpVals(jsonNode)
+	result, err := doif.NewCheckTypeOpNode(fieldPath, vals)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init check_type op: %w", err)
+	}
+	return result, nil
+}
+
 func extractLogicalOpNode(opName string, jsonNode *simplejson.Json) (doif.Node, error) {
 	var result, operand doif.Node
 	var err error
@@ -434,6 +451,8 @@ func extractDoIfNode(jsonNode *simplejson.Json) (doif.Node, error) {
 		return extractLengthCmpOpNode(opName, jsonNode)
 	} else if _, has := doIfTimestampCmpOpNodes[opName]; has {
 		return extractTsCmpOpNode(opName, jsonNode)
+	} else if opName == checkTypeOpName {
+		return extractCheckTypeOpNode(opName, jsonNode)
 	} else {
 		return nil, fmt.Errorf("unknown op %q", opName)
 	}

--- a/fd/util.go
+++ b/fd/util.go
@@ -221,7 +221,7 @@ var (
 	doIfTimestampCmpOpNodes = map[string]struct{}{
 		"ts_cmp": {},
 	}
-	checkTypeOpName = "check_type"
+	doIfСheckTypeOpNode = "check_type"
 )
 
 func extractFieldOpVals(jsonNode *simplejson.Json) [][]byte {
@@ -451,7 +451,7 @@ func extractDoIfNode(jsonNode *simplejson.Json) (doif.Node, error) {
 		return extractLengthCmpOpNode(opName, jsonNode)
 	} else if _, has := doIfTimestampCmpOpNodes[opName]; has {
 		return extractTsCmpOpNode(opName, jsonNode)
-	} else if opName == checkTypeOpName {
+	} else if opName == doIfСheckTypeOpNode {
 		return extractCheckTypeOpNode(opName, jsonNode)
 	} else {
 		return nil, fmt.Errorf("unknown op %q", opName)

--- a/pipeline/doif/README.idoc.md
+++ b/pipeline/doif/README.idoc.md
@@ -25,3 +25,6 @@ the chain of Match func calls are performed across the whole tree.
 
 ### Timestamp comparison op node
 @do-if-ts-cmp-op-node
+
+### Check type op node
+@do-if-check-type-op-node

--- a/pipeline/doif/README.md
+++ b/pipeline/doif/README.md
@@ -18,6 +18,10 @@ the chain of Match func calls are performed across the whole tree.
 
 <br>
 
+**`CheckTypeOp`** Type of node where matching rules for check types are stored.
+
+<br>
+
 **`LogicalOp`** Type of node where logical rules for applying other rules are stored.
 
 <br>
@@ -397,6 +401,36 @@ Result:
 {"timestamp":"qwe"}  # not discarded (field `timestamp` is not parsable)
 
 {"timestamp":"2011-01-01T00:00:00Z"}  # not discarded (condition is not met)
+```
+
+### Check type op node
+DoIf check type op node checks whether the type of the field node is the one from the list.
+
+Params:
+  - `op` - for that node the value is `check_type`
+  - `field` - path to JSON node, can be empty string meaning root node, can be nested field `field.subfield` (if the field consists of `.` in the name, it must be shielded e.g. `exception\.type`)
+  - `values` - list of types to check against. Allowed values are `obj`, `arr`, `number` (both ints or floats), `string`, `null`, `nil` (for the abscent fields).
+
+Example:
+
+```yaml
+- type: discard
+  do_if:
+	op: not
+	operands:
+      - op: check_type
+	    field: log
+	    values: [obj, arr]
+```
+
+result:
+```
+{"log":{"message":"test"}}   # not discarded
+{"log":[{"message":"test"}]} # not discarded
+{"log":"test"}               # discarded
+{"log":123}                  # discarded
+{"log":null}                 # discarded
+{"not_log":{"test":"test"}}  # discarded
 ```
 
 <br>*Generated using [__insane-doc__](https://github.com/vitkovskii/insane-doc)*

--- a/pipeline/doif/README.md
+++ b/pipeline/doif/README.md
@@ -416,11 +416,11 @@ Example:
 ```yaml
 - type: discard
   do_if:
-	op: not
-	operands:
+    op: not
+    operands:
       - op: check_type
-	    field: log
-	    values: [obj, arr]
+        field: log
+        values: [obj, arr]
 ```
 
 result:

--- a/pipeline/doif/README.md
+++ b/pipeline/doif/README.md
@@ -409,7 +409,7 @@ DoIf check type op node checks whether the type of the field node is the one fro
 Params:
   - `op` - for that node the value is `check_type`
   - `field` - path to JSON node, can be empty string meaning root node, can be nested field `field.subfield` (if the field consists of `.` in the name, it must be shielded e.g. `exception\.type`)
-  - `values` - list of types to check against. Allowed values are `obj`, `arr`, `number` (both ints or floats), `string`, `null`, `nil` (for the abscent fields).
+  - `values` - list of types to check against. Allowed values are `object` (or `obj`), `array` (or `arr`), `number` (or `num`, matches both ints or floats), `string` (or `str`), `null`, `nil` (for the abscent fields). Values are deduplicated with respect to aliases on initialization to prevent redundant checks.
 
 Example:
 

--- a/pipeline/doif/check_type_op.go
+++ b/pipeline/doif/check_type_op.go
@@ -23,11 +23,11 @@ Example:
 ```yaml
 - type: discard
   do_if:
-	op: not
-	operands:
+    op: not
+    operands:
       - op: check_type
-	    field: log
-	    values: [obj, arr]
+        field: log
+        values: [obj, arr]
 ```
 
 result:

--- a/pipeline/doif/check_type_op.go
+++ b/pipeline/doif/check_type_op.go
@@ -1,0 +1,169 @@
+package doif
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/ozontech/file.d/cfg"
+	insaneJSON "github.com/vitkovskii/insane-json"
+)
+
+/*{ do-if-check-type-op-node
+DoIf check type op node checks whether the type of the field node is the one from the list.
+
+Params:
+  - `op` - for that node the value is `check_type`
+  - `field` - path to JSON node, can be empty string meaning root node, can be nested field `field.subfield` (if the field consists of `.` in the name, it must be shielded e.g. `exception\.type`)
+  - `values` - list of types to check against. Allowed values are `obj`, `arr`, `number` (both ints or floats), `string`, `null`, `nil` (for the abscent fields).
+
+Example:
+
+```yaml
+- type: discard
+  do_if:
+	op: not
+	operands:
+      - op: check_type
+	    field: log
+	    values: [obj, arr]
+```
+
+result:
+```
+{"log":{"message":"test"}}   # not discarded
+{"log":[{"message":"test"}]} # not discarded
+{"log":"test"}               # discarded
+{"log":123}                  # discarded
+{"log":null}                 # discarded
+{"not_log":{"test":"test"}}  # discarded
+```
+}*/
+
+type checkType int
+
+const (
+	checkTypeUnknown checkType = iota
+	checkTypeObj
+	checkTypeArr
+	checkTypeNumber
+	checkTypeString
+	checkTypeNull
+	checkTypeNil
+)
+
+var (
+	checkTypeUnknownTag = []byte("unknown")
+	checkTypeObjTag     = []byte("obj")
+	checkTypeArrTag     = []byte("arr")
+	checkTypeNumberTag  = []byte("number")
+	checkTypeStringTag  = []byte("string")
+	checkTypeNullTag    = []byte("null")
+	checkTypeNilTag     = []byte("nil")
+)
+
+func (t checkType) String() string {
+	switch t {
+	case checkTypeObj:
+		return string(checkTypeObjTag)
+	case checkTypeArr:
+		return string(checkTypeArrTag)
+	case checkTypeNumber:
+		return string(checkTypeNumberTag)
+	case checkTypeString:
+		return string(checkTypeStringTag)
+	case checkTypeNull:
+		return string(checkTypeNullTag)
+	case checkTypeNil:
+		return string(checkTypeNilTag)
+	default:
+		return string(checkTypeUnknownTag)
+	}
+}
+
+type checkTypeOpNode struct {
+	fieldPath    []string
+	fieldPathStr string
+	checkTypes   []checkType
+}
+
+func NewCheckTypeOpNode(field string, values [][]byte) (Node, error) {
+	if len(values) == 0 {
+		return nil, errors.New("values are not provided")
+	}
+	fieldPath := cfg.ParseFieldSelector(field)
+	checkTypes := make([]checkType, 0)
+	for _, val := range values {
+		switch {
+		case bytes.Equal(val, checkTypeObjTag):
+			checkTypes = append(checkTypes, checkTypeObj)
+		case bytes.Equal(val, checkTypeArrTag):
+			checkTypes = append(checkTypes, checkTypeArr)
+		case bytes.Equal(val, checkTypeNumberTag):
+			checkTypes = append(checkTypes, checkTypeNumber)
+		case bytes.Equal(val, checkTypeStringTag):
+			checkTypes = append(checkTypes, checkTypeString)
+		case bytes.Equal(val, checkTypeNullTag):
+			checkTypes = append(checkTypes, checkTypeNull)
+		case bytes.Equal(val, checkTypeNilTag):
+			checkTypes = append(checkTypes, checkTypeNil)
+		default:
+			return nil, fmt.Errorf(
+				"invalid value for check_type: %q. Allowed values are: 'obj','arr','number','string','null','nil'",
+				val,
+			)
+		}
+	}
+	return &checkTypeOpNode{
+		fieldPath:    fieldPath,
+		fieldPathStr: field,
+		checkTypes:   checkTypes,
+	}, nil
+}
+
+func (n *checkTypeOpNode) Type() NodeType {
+	return NodeCheckTypeOp
+}
+
+func (n *checkTypeOpNode) Check(eventRoot *insaneJSON.Root) bool {
+	node := eventRoot.Dig(n.fieldPath...)
+	for _, t := range n.checkTypes {
+		switch {
+		case t == checkTypeNull && node.IsNull():
+			return true
+		case t == checkTypeObj && node.IsObject():
+			return true
+		case t == checkTypeArr && node.IsArray():
+			return true
+		case t == checkTypeNumber && node.IsNumber():
+			return true
+		case t == checkTypeString && node.IsString():
+			return true
+		case t == checkTypeNil && node.IsNil():
+			return true
+		}
+	}
+	return false
+}
+
+func (n *checkTypeOpNode) isEqualTo(n2 Node, _ int) error {
+	n2f, ok := n2.(*checkTypeOpNode)
+	if !ok {
+		return errors.New("nodes have different types expected: checkTypeOpNode")
+	}
+	if n.fieldPathStr != n2f.fieldPathStr || slices.Compare[[]string](n.fieldPath, n2f.fieldPath) != 0 {
+		return fmt.Errorf("nodes have different fieldPathStr expected: fieldPathStr=%q fieldPath=%v",
+			n.fieldPathStr, n.fieldPath,
+		)
+	}
+	if len(n.checkTypes) != len(n2f.checkTypes) {
+		return fmt.Errorf("nodes have different checkTypes slices len expected: %d", len(n.checkTypes))
+	}
+	for i := 0; i < len(n.checkTypes); i++ {
+		if n.checkTypes[i] != n2f.checkTypes[i] {
+			return fmt.Errorf("nodes have different data in checkTypes expected: %s on position", n.checkTypes)
+		}
+	}
+	return nil
+}

--- a/pipeline/doif/check_type_test.go
+++ b/pipeline/doif/check_type_test.go
@@ -1,0 +1,221 @@
+package doif
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	insaneJSON "github.com/vitkovskii/insane-json"
+)
+
+type testCheckTypeNode struct {
+	field  string
+	values [][]byte
+}
+
+func TestCheckType(t *testing.T) {
+	t.Parallel()
+	type argsResp struct {
+		eventStr string
+		want     bool
+	}
+
+	tests := []struct {
+		name string
+		node testCheckTypeNode
+		data []argsResp
+	}{
+		{
+			name: "ok_type_obj",
+			node: testCheckTypeNode{
+				field:  "log",
+				values: [][]byte{[]byte("obj")},
+			},
+			data: []argsResp{
+				{
+					eventStr: `{"log":{"sublog":"test"}}`,
+					want:     true,
+				},
+				{
+					eventStr: `{"log":"test"}`,
+					want:     false,
+				},
+				{
+					eventStr: `"test"`,
+					want:     false,
+				},
+			},
+		},
+		{
+			name: "ok_type_arr",
+			node: testCheckTypeNode{
+				field:  "log",
+				values: [][]byte{[]byte("arr")},
+			},
+			data: []argsResp{
+				{
+					eventStr: `{"log":[{"sublog":"test"}]}`,
+					want:     true,
+				},
+				{
+					eventStr: `{"log":"test"}`,
+					want:     false,
+				},
+				{
+					eventStr: `"test"`,
+					want:     false,
+				},
+			},
+		},
+		{
+			name: "ok_type_number",
+			node: testCheckTypeNode{
+				field:  "log",
+				values: [][]byte{[]byte("number")},
+			},
+			data: []argsResp{
+				{
+					eventStr: `{"log":123}`,
+					want:     true,
+				},
+				{
+					eventStr: `{"log":"test"}`,
+					want:     false,
+				},
+				{
+					eventStr: `"test"`,
+					want:     false,
+				},
+			},
+		},
+		{
+			name: "ok_type_string",
+			node: testCheckTypeNode{
+				field:  "log",
+				values: [][]byte{[]byte("string")},
+			},
+			data: []argsResp{
+				{
+					eventStr: `{"log":"test"}`,
+					want:     true,
+				},
+				{
+					eventStr: `{"log":{"subfield":"test"}}`,
+					want:     false,
+				},
+				{
+					eventStr: `"test"`,
+					want:     false,
+				},
+			},
+		},
+		{
+			name: "ok_type_null",
+			node: testCheckTypeNode{
+				field:  "log",
+				values: [][]byte{[]byte("null")},
+			},
+			data: []argsResp{
+				{
+					eventStr: `{"log":null}`,
+					want:     true,
+				},
+				{
+					eventStr: `{"log":"test"}`,
+					want:     false,
+				},
+				{
+					eventStr: `"test"`,
+					want:     false,
+				},
+			},
+		},
+		{
+			name: "ok_type_nil",
+			node: testCheckTypeNode{
+				field:  "log",
+				values: [][]byte{[]byte("nil")},
+			},
+			data: []argsResp{
+				{
+					eventStr: `{"not_log":null}`,
+					want:     true,
+				},
+				{
+					eventStr: `{"log":"test"}`,
+					want:     false,
+				},
+				{
+					eventStr: `"test"`,
+					want:     true,
+				},
+			},
+		},
+		{
+			name: "ok_multiple_types",
+			node: testCheckTypeNode{
+				field:  "log",
+				values: [][]byte{[]byte("obj"), []byte("arr")},
+			},
+			data: []argsResp{
+				{
+					eventStr: `{"log":{"subfield":"test"}}`,
+					want:     true,
+				},
+				{
+					eventStr: `{"log":[{"subfield":"test"}]}`,
+					want:     true,
+				},
+				{
+					eventStr: `{"log":"test"}`,
+					want:     false,
+				},
+				{
+					eventStr: `"test"`,
+					want:     false,
+				},
+			},
+		},
+		{
+			name: "ok_root_is_obj_or_arr",
+			node: testCheckTypeNode{
+				field:  "",
+				values: [][]byte{[]byte("obj"), []byte("arr")},
+			},
+			data: []argsResp{
+				{
+					eventStr: `{"log":{"subfield":"test"}}`,
+					want:     true,
+				},
+				{
+					eventStr: `[{"log":{"subfield":"test"}}]`,
+					want:     true,
+				},
+				{
+					eventStr: `"test"`,
+					want:     false,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var eventRoot *insaneJSON.Root
+			node, err := NewCheckTypeOpNode(tt.node.field, tt.node.values)
+			require.NoError(t, err)
+			for _, d := range tt.data {
+				if d.eventStr == "" {
+					eventRoot = nil
+				} else {
+					eventRoot, err = insaneJSON.DecodeString(d.eventStr)
+					require.NoError(t, err)
+				}
+				got := node.Check(eventRoot)
+				assert.Equal(t, d.want, got, "invalid result for event %q", d.eventStr)
+			}
+		})
+	}
+}

--- a/pipeline/doif/do_if.go
+++ b/pipeline/doif/do_if.go
@@ -21,6 +21,9 @@ const (
 	// > Type of node where matching rules for timestamps are stored.
 	NodeTimestampCmpOp // *
 
+	// > Type of node where matching rules for check types are stored.
+	NodeCheckTypeOp // *
+
 	// > Type of node where logical rules for applying other rules are stored.
 	NodeLogicalOp // *
 )

--- a/pipeline/doif/field_op.go
+++ b/pipeline/doif/field_op.go
@@ -202,9 +202,6 @@ type fieldOpNode struct {
 }
 
 func NewFieldOpNode(op string, field string, caseSensitive bool, values [][]byte) (Node, error) {
-	if field == "" {
-		return nil, errors.New("field is not specified")
-	}
 	if len(values) == 0 {
 		return nil, errors.New("values are not provided")
 	}


### PR DESCRIPTION
# Description

This PR adds operation in do_if for checking types of JSON nodes (including root node). Allowed values are `obj`, `arr`, `number`, `string`, `null`, `nil` (nil means the node is absent).

Example:

```yaml
- type: "discard"
  do_if:
    op: "not"
    operands:
      - op: "check_type"
        field: "log"
        values: ["obj", "arr"]
```

That will discard all logs where `log` field is not an object or an array.

Fixes #694 