### PR TITLE
fix kafka consumer memory leak: use fetches channel

### DIFF
--- a/plugin/input/kafka/README.md
+++ b/plugin/input/kafka/README.md
@@ -59,6 +59,13 @@ The number of unprocessed messages in the buffer that are loaded in the backgrou
 
 <br>
 
+**`max_concurrent_consumers`** *`int`* *`default=5`* 
+MaxConcurrentConsumers sets the maximum number of consumers
+Optimal value: number of topics * number of partitions of topic
+
+
+<br>
+
 **`max_concurrent_fetches`** *`int`* *`default=0`* 
 
 MaxConcurrentFetches sets the maximum number of fetch requests to allow in

--- a/plugin/input/kafka/kafka.go
+++ b/plugin/input/kafka/kafka.go
@@ -98,6 +98,12 @@ type Config struct {
 	ChannelBufferSize int `json:"channel_buffer_size" default:"256"` // *
 
 	// > @3@4@5@6
+	// > MaxConcurrentConsumers sets the maximum number of consumers
+	// > Optimal value: number of topics * number of partitions of topic
+	// >
+	MaxConcurrentConsumers int `json:"max_concurrent_consumers" default:"5"` // *
+
+	// > @3@4@5@6
 	// >
 	// > MaxConcurrentFetches sets the maximum number of fetch requests to allow in
 	// > flight or buffered at once, overriding the unbounded (i.e. number of
@@ -281,13 +287,14 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.InputPluginPa
 	ctx, cancel := context.WithCancel(context.Background())
 	p.cancel = cancel
 	p.s = &splitConsume{
-		consumers:           make(map[tp]*pconsumer),
-		bufferSize:          p.config.ChannelBufferSize,
-		idByTopic:           p.idByTopic,
-		controller:          p.controller,
-		logger:              p.logger.Desugar(),
-		metaTemplater:       p.metaTemplater,
-		consumeErrorsMetric: p.consumeErrorsMetric,
+		consumers:              make(map[tp]*pconsumer),
+		bufferSize:             p.config.ChannelBufferSize,
+		maxConcurrentConsumers: p.config.MaxConcurrentConsumers,
+		idByTopic:              p.idByTopic,
+		controller:             p.controller,
+		logger:                 p.logger.Desugar(),
+		metaTemplater:          p.metaTemplater,
+		consumeErrorsMetric:    p.consumeErrorsMetric,
 	}
 	p.client = NewClient(p.config, p.logger.Desugar(), p.s)
 	p.controller.UseSpread()


### PR DESCRIPTION
We see memory leaks when output is slow.
Channel for fetches makes it possible to stop fetch partitions when output is slow.

Inspiring by franz-go [sample](https://github.com/twmb/franz-go/blob/master/examples/goroutine_per_partition_consuming/autocommit_marks/main.go)