### PR TITLE
Fix nginx_error decoder with custom fields

### DIFF
--- a/decoder/nginx.go
+++ b/decoder/nginx.go
@@ -86,13 +86,15 @@ func (d *NginxErrorDecoder) DecodeToJson(root *insaneJSON.Root, data []byte) err
 	return nil
 }
 
-// DecodeNginxError decodes nginx error formated log to [NginxErrorRow].
+// Decode decodes nginx error formated log to [NginxErrorRow].
 //
 // Example of format:
 //
 //	"2022/08/17 10:49:27 [error] 2725122#2725122: *792412315 lua udp socket read timed out, context: ngx.timer"
 func (d *NginxErrorDecoder) Decode(data []byte) (any, error) {
 	row := NginxErrorRow{}
+
+	data = bytes.TrimSuffix(data, []byte("\n"))
 
 	split := spaceSplit(data, 5)
 	if len(split) < 4 {

--- a/decoder/nginx_test.go
+++ b/decoder/nginx_test.go
@@ -19,7 +19,7 @@ func TestNginxError(t *testing.T) {
 	}{
 		{
 			name:  "valid_full",
-			input: `2022/08/18 09:29:37 [error] 844935#844935: *44934601 upstream timed out (110: Operation timed out) while connecting to upstream, client: 10.125.172.251, server: mpm-youtube-downloader-38.name.tldn, request: "POST /download HTTP/1.1", upstream: "http://10.117.246.15:84/download", host: "mpm-youtube-downloader-38.name.tldn:84"`,
+			input: `2022/08/18 09:29:37 [error] 844935#844935: *44934601 upstream timed out (110: Operation timed out) while connecting to upstream, client: 10.125.172.251, server: mpm-youtube-downloader-38.name.tldn, request: "POST /download HTTP/1.1", upstream: "http://10.117.246.15:84/download", host: "mpm-youtube-downloader-38.name.tldn:84"` + "\n",
 			want: NginxErrorRow{
 				Time:    []byte("2022/08/18 09:29:37"),
 				Level:   []byte("error"),
@@ -63,7 +63,7 @@ func TestNginxError(t *testing.T) {
 		},
 		{
 			name:  "valid_custom_fields",
-			input: `2022/08/18 09:29:37 [error] 844935#844935: *44934601 upstream timed out (110: Operation timed out), while connecting to upstream, client: 10.125.172.251, server: , request: "POST /download HTTP/1.1", upstream: "http://10.117.246.15:84/download", host: "mpm-youtube-downloader-38.name.tldn:84"`,
+			input: `2022/08/18 09:29:37 [error] 844935#844935: *44934601 upstream timed out (110: Operation timed out), while connecting to upstream, client: 10.125.172.251, server: , request: "POST /download HTTP/1.1", upstream: "http://10.117.246.15:84/download", host: "mpm-youtube-downloader-38.name.tldn:84"` + "\n",
 			params: map[string]any{
 				nginxWithCustomFieldsParam: true,
 			},

--- a/plugin/action/decode/decode_test.go
+++ b/plugin/action/decode/decode_test.go
@@ -120,7 +120,7 @@ func TestDecode(t *testing.T) {
 				Field:   "log",
 				Decoder: "nginx_error",
 			},
-			input: []byte(`{"level":"warn","log":"2022/08/17 10:49:27 [error] 2725122#2725122: *792412315 lua udp socket read timed out, context: ngx.timer"}`),
+			input: []byte(`{"level":"warn","log":"2022/08/17 10:49:27 [error] 2725122#2725122: *792412315 lua udp socket read timed out, context: ngx.timer\n"}`),
 			want: map[string]string{
 				"level":   "error",
 				"time":    "2022/08/17 10:49:27",
@@ -157,7 +157,7 @@ func TestDecode(t *testing.T) {
 					"nginx_with_custom_fields": true,
 				},
 			},
-			input: []byte(`{"level":"warn","log":"2022/08/18 09:29:37 [error] 844935#844935: *44934601 upstream timed out (110: Operation timed out), while connecting to upstream, client: 10.125.172.251, server: , request: \"POST /download HTTP/1.1\", upstream: \"http://10.117.246.15:84/download\", host: \"mpm-youtube-downloader-38.name.tldn:84\""}`),
+			input: []byte(`{"level":"warn","log":"2022/08/18 09:29:37 [error] 844935#844935: *44934601 upstream timed out (110: Operation timed out), while connecting to upstream, client: 10.125.172.251, server: , request: \"POST /download HTTP/1.1\", upstream: \"http://10.117.246.15:84/download\", host: \"mpm-youtube-downloader-38.name.tldn:84\"\n"}`),
 			want: map[string]string{
 				"level":    "error",
 				"time":     "2022/08/18 09:29:37",


### PR DESCRIPTION
# Description

Fix decoding nginx_error log with `\n` at the end.