### PR TITLE
Release events after they have been sent

### DIFF
--- a/pipeline/batch.go
+++ b/pipeline/batch.go
@@ -246,6 +246,7 @@ func (b *Batcher) commitBatch(batch *Batch) BatchStatus {
 
 	for i := range batch.events {
 		b.opts.Controller.Commit(batch.events[i])
+		batch.events[i] = nil
 	}
 
 	status := batch.status


### PR DESCRIPTION
Release events after they have been sent. It is follow up for #689.