### PR TITLE
K8s-multiline cut off long events by limit

### DIFF
--- a/fd/util.go
+++ b/fd/util.go
@@ -23,7 +23,7 @@ func extractPipelineParams(settings *simplejson.Json) *pipeline.Settings {
 	avgInputEventSize := pipeline.DefaultAvgInputEventSize
 	maxInputEventSize := pipeline.DefaultMaxInputEventSize
 	cutOffEventByLimit := pipeline.DefaultCutOffEventByLimit
-	cutOffEventByLimitMsg := pipeline.DefaultCutOffEventByLimitMsg
+	cutOffEventByLimitField := pipeline.DefaultCutOffEventByLimitField
 	streamField := pipeline.DefaultStreamField
 	maintenanceInterval := pipeline.DefaultMaintenanceInterval
 	decoder := pipeline.DefaultDecoder
@@ -56,11 +56,7 @@ func extractPipelineParams(settings *simplejson.Json) *pipeline.Settings {
 		}
 
 		cutOffEventByLimit = settings.Get("cut_off_event_by_limit").MustBool()
-
-		cutOffEventByLimitMsg = settings.Get("cut_off_event_by_limit_message").MustString()
-		if maxInputEventSize > 0 && len(cutOffEventByLimitMsg) >= maxInputEventSize {
-			logger.Fatal("length of cut_off_event_by_limit_message must be less than max_event_size")
-		}
+		cutOffEventByLimitField = settings.Get("cut_off_event_by_limit_field").MustString()
 
 		str := settings.Get("decoder").MustString()
 		if str != "" {
@@ -124,23 +120,23 @@ func extractPipelineParams(settings *simplejson.Json) *pipeline.Settings {
 	}
 
 	return &pipeline.Settings{
-		Decoder:               decoder,
-		DecoderParams:         decoderParams,
-		Capacity:              capacity,
-		MetaCacheSize:         metaCacheSize,
-		AvgEventSize:          avgInputEventSize,
-		MaxEventSize:          maxInputEventSize,
-		CutOffEventByLimit:    cutOffEventByLimit,
-		CutOffEventByLimitMsg: cutOffEventByLimitMsg,
-		AntispamThreshold:     antispamThreshold,
-		AntispamExceptions:    antispamExceptions,
-		SourceNameMetaField:   sourceNameMetaField,
-		MaintenanceInterval:   maintenanceInterval,
-		EventTimeout:          eventTimeout,
-		StreamField:           streamField,
-		IsStrict:              isStrict,
-		MetricHoldDuration:    metricHoldDuration,
-		Pool:                  pipeline.PoolType(pool),
+		Decoder:                 decoder,
+		DecoderParams:           decoderParams,
+		Capacity:                capacity,
+		MetaCacheSize:           metaCacheSize,
+		AvgEventSize:            avgInputEventSize,
+		MaxEventSize:            maxInputEventSize,
+		CutOffEventByLimit:      cutOffEventByLimit,
+		CutOffEventByLimitField: cutOffEventByLimitField,
+		AntispamThreshold:       antispamThreshold,
+		AntispamExceptions:      antispamExceptions,
+		SourceNameMetaField:     sourceNameMetaField,
+		MaintenanceInterval:     maintenanceInterval,
+		EventTimeout:            eventTimeout,
+		StreamField:             streamField,
+		IsStrict:                isStrict,
+		MetricHoldDuration:      metricHoldDuration,
+		Pool:                    pipeline.PoolType(pool),
 	}
 }
 

--- a/plugin/input/k8s/multiline_action.go
+++ b/plugin/input/k8s/multiline_action.go
@@ -12,14 +12,18 @@ type MultilineAction struct {
 	allowedPodLabels  map[string]bool
 	allowedNodeLabels map[string]bool
 
-	logger              *zap.SugaredLogger
-	controller          pipeline.ActionPluginController
-	maxEventSize        int
-	sourceNameMetaField string
+	logger     *zap.SugaredLogger
+	controller pipeline.ActionPluginController
+
+	maxEventSize          int
+	sourceNameMetaField   string
+	cutOffEventByLimit    bool
+	cutOffEventByLimitMsg string
 
 	eventBuf      []byte
 	eventSize     int
 	skipNextEvent bool
+	cutOffEvent   bool
 }
 
 const (
@@ -32,6 +36,9 @@ func (p *MultilineAction) Start(config pipeline.AnyConfig, params *pipeline.Acti
 	p.controller = params.Controller
 	p.maxEventSize = params.PipelineSettings.MaxEventSize
 	p.sourceNameMetaField = params.PipelineSettings.SourceNameMetaField
+	p.cutOffEventByLimit = params.PipelineSettings.CutOffEventByLimit
+	p.cutOffEventByLimitMsg = params.PipelineSettings.CutOffEventByLimitMsg
+
 	p.config = config.(*Config)
 
 	p.allowedPodLabels = cfg.ListToMap(p.config.AllowedPodLabels)
@@ -110,7 +117,17 @@ func (p *MultilineAction) Do(event *pipeline.Event) pipeline.ActionResult {
 
 			// skip event if max_event_size is exceeded
 			p.skipNextEvent = true
-			p.logger.Errorf("event chunk will be discarded due to max_event_size, source_name=%s, namespace=%s, pod=%s", event.SourceName, ns, pod)
+
+			if p.cutOffEventByLimit {
+				offset := sizeAfterAppend - p.maxEventSize
+				p.eventBuf = append(p.eventBuf, logFragment[1:logFragmentLen-1-offset]...)
+				p.eventBuf = append(p.eventBuf, p.cutOffEventByLimitMsg...)
+				p.cutOffEvent = true
+
+				p.logger.Errorf("event chunk will be cut off due to max_event_size, source_name=%s, namespace=%s, pod=%s", event.SourceName, ns, pod)
+			} else {
+				p.logger.Errorf("event chunk will be discarded due to max_event_size, source_name=%s, namespace=%s, pod=%s", event.SourceName, ns, pod)
+			}
 		}
 		return pipeline.ActionCollapse
 	}
@@ -121,8 +138,11 @@ func (p *MultilineAction) Do(event *pipeline.Event) pipeline.ActionResult {
 			return pipeline.ActionCollapse
 		}
 		p.skipNextEvent = false
-		p.resetLogBuf()
-		return pipeline.ActionDiscard
+
+		if !p.cutOffEvent {
+			p.resetLogBuf()
+			return pipeline.ActionDiscard
+		}
 	}
 
 	success, podMeta := meta.GetPodMeta(ns, pod, containerID)
@@ -164,7 +184,11 @@ func (p *MultilineAction) Do(event *pipeline.Event) pipeline.ActionResult {
 	}
 
 	if len(p.eventBuf) > 1 {
-		p.eventBuf = append(p.eventBuf, logFragment[1:logFragmentLen-1]...)
+		if !p.cutOffEvent {
+			p.eventBuf = append(p.eventBuf, logFragment[1:logFragmentLen-1]...)
+		} else if isEnd {
+			p.eventBuf = append(p.eventBuf, newLine...)
+		}
 		p.eventBuf = append(p.eventBuf, '"')
 
 		l := len(event.Buf)
@@ -179,4 +203,5 @@ func (p *MultilineAction) Do(event *pipeline.Event) pipeline.ActionResult {
 func (p *MultilineAction) resetLogBuf() {
 	p.eventBuf = p.eventBuf[:1]
 	p.eventSize = 0
+	p.cutOffEvent = false
 }


### PR DESCRIPTION
# Description

Cut off long events by limit in `k8s-multiline` action by `cut_off_event_by_limit` pipeline setting.