### PR TITLE
fix when k8s meta is empty

### DIFF
--- a/plugin/input/file/worker.go
+++ b/plugin/input/file/worker.go
@@ -225,17 +225,28 @@ func newMetaInformation(filename, symlink string, inode inodeID, offset int64, p
 }
 
 func (m metaInformation) GetData() map[string]any {
-	return map[string]any{
-		"filename":       m.filename,
-		"symlink":        m.symlink,
-		"inode":          m.inode,
-		"offset":         m.offset,
-		"pod_name":       m.k8sMetadata.PodName,
-		"namespace":      m.k8sMetadata.Namespace,
-		"container_name": m.k8sMetadata.ContainerName,
-		"container_id":   m.k8sMetadata.ContainerID,
-		"pod":            m.k8sMetadata.Pod,
+	data := map[string]any{
+		"filename": m.filename,
+		"symlink":  m.symlink,
+		"inode":    m.inode,
+		"offset":   m.offset,
 	}
+
+	if m.k8sMetadata != nil {
+		data["pod_name"] = m.k8sMetadata.PodName
+		data["namespace"] = m.k8sMetadata.Namespace
+		data["container_name"] = m.k8sMetadata.ContainerName
+		data["container_id"] = m.k8sMetadata.ContainerID
+		data["pod"] = m.k8sMetadata.Pod
+	} else {
+		data["pod_name"] = nil
+		data["namespace"] = nil
+		data["container_name"] = nil
+		data["container_id"] = nil
+		data["pod"] = nil
+	}
+
+	return data
 }
 
 /*{ meta-params

--- a/plugin/input/file/worker_test.go
+++ b/plugin/input/file/worker_test.go
@@ -440,6 +440,25 @@ func TestGetData(t *testing.T) {
 				"container_id":   "4e0301b633eaa2bfdcafdeba59ba0c72a3815911a6a820bf273534b0f32d98e0",
 			},
 		},
+		{
+			name: "No k8s data",
+			metaInfo: metaInformation{
+				filename: "/container.log",
+				symlink:  "/k8s-logs/container.log",
+				inode:    12345,
+				offset:   0,
+			},
+			expected: map[string]any{
+				"filename":       "/container.log",
+				"symlink":        "/k8s-logs/container.log",
+				"inode":          uint64(12345),
+				"offset":         int64(0),
+				"pod_name":       nil,
+				"namespace":      nil,
+				"container_name": nil,
+				"container_id":   nil,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The k8s-input plugin expects a log filename in a specific format, but sometimes we have a name like /container.log

