### PR TITLE
Fix Int64&UInt64 in clickhouse output

### DIFF
--- a/plugin/output/clickhouse/colgenerator/colgenerator.go
+++ b/plugin/output/clickhouse/colgenerator/colgenerator.go
@@ -103,7 +103,7 @@ func clickhouseTypes() []Type {
 			types = append(types, Type{
 				ChTypeName:  protoName,
 				GoName:      goName,
-				Convertable: true,
+				Convertable: bits != 64,
 				Nullable:    true,
 			})
 		}

--- a/plugin/output/clickhouse/colgenerator/type.go
+++ b/plugin/output/clickhouse/colgenerator/type.go
@@ -48,6 +48,10 @@ func (t Type) InsaneConvertFunc() string {
 		return "AsFloat32"
 	case "float64":
 		return "AsFloat64"
+	case "int64":
+		return "AsInt64"
+	case "uint64":
+		return "AsUint64"
 	default:
 		return "AsInt"
 	}

--- a/plugin/output/clickhouse/column_gen.go
+++ b/plugin/output/clickhouse/column_gen.go
@@ -664,12 +664,10 @@ func (t *ColInt64) Append(node InsaneNode) error {
 		return nil
 	}
 
-	v, err := node.AsInt()
+	val, err := node.AsInt64()
 	if err != nil {
 		return err
 	}
-
-	val := int64(v)
 
 	if t.nullable {
 		t.nullCol.Append(proto.NewNullable(val))
@@ -739,12 +737,10 @@ func (t *ColUInt64) Append(node InsaneNode) error {
 		return nil
 	}
 
-	v, err := node.AsInt()
+	val, err := node.AsUint64()
 	if err != nil {
 		return err
 	}
-
-	val := uint64(v)
 
 	if t.nullable {
 		t.nullCol.Append(proto.NewNullable(val))

--- a/plugin/output/clickhouse/insanenode.go
+++ b/plugin/output/clickhouse/insanenode.go
@@ -17,11 +17,12 @@ var (
 
 type InsaneNode interface {
 	AsInt() (int, error)
+	AsInt64() (int64, error)
+	AsUint64() (uint64, error)
 	AsFloat32() (float32, error)
 	AsFloat64() (float64, error)
 	AsString() (string, error)
 	AsBool() (bool, error)
-	AsInt64() (int64, error)
 	AsStringArray() ([]string, error)
 	AsUUID() (uuid.UUID, error)
 	AsIPv4() (proto.IPv4, error)
@@ -139,6 +140,14 @@ func (n NonStrictNode) AsInt() (int, error) {
 	return n.Node.AsInt(), nil
 }
 
+func (n NonStrictNode) AsInt64() (int64, error) {
+	return n.Node.AsInt64(), nil
+}
+
+func (n NonStrictNode) AsUint64() (uint64, error) {
+	return n.Node.AsUint64(), nil
+}
+
 func (n NonStrictNode) AsFloat32() (float32, error) {
 	return float32(n.AsFloat()), nil
 }
@@ -156,10 +165,6 @@ func (n NonStrictNode) AsString() (string, error) {
 
 func (n NonStrictNode) AsBool() (bool, error) {
 	return n.Node.AsBool(), nil
-}
-
-func (n NonStrictNode) AsInt64() (int64, error) {
-	return n.Node.AsInt64(), nil
 }
 
 func (n NonStrictNode) AsUUID() (uuid.UUID, error) {
@@ -219,6 +224,14 @@ func (z ZeroValueNode) AsInt() (int, error) {
 	return 0, nil
 }
 
+func (z ZeroValueNode) AsInt64() (int64, error) {
+	return 0, nil
+}
+
+func (z ZeroValueNode) AsUint64() (uint64, error) {
+	return 0, nil
+}
+
 func (z ZeroValueNode) AsFloat32() (float32, error) {
 	return 0, nil
 }
@@ -233,10 +246,6 @@ func (z ZeroValueNode) AsString() (string, error) {
 
 func (z ZeroValueNode) AsBool() (bool, error) {
 	return false, nil
-}
-
-func (z ZeroValueNode) AsInt64() (int64, error) {
-	return 0, nil
 }
 
 func (z ZeroValueNode) AsStringArray() ([]string, error) {

--- a/plugin/output/clickhouse/insanenode_test.go
+++ b/plugin/output/clickhouse/insanenode_test.go
@@ -42,6 +42,8 @@ func TestZeroValueNode(t *testing.T) {
 			NewColUInt16(nullable),
 			NewColInt32(nullable),
 			NewColUInt32(nullable),
+			NewColInt64(nullable),
+			NewColUInt64(nullable),
 			NewColInt128(nullable),
 			NewColUInt128(nullable),
 			NewColIPv4(nullable),


### PR DESCRIPTION
# Description

Fix `Int64` and `UInt64` clickhouse column types.