### PR TITLE
[#0] - removed duplicate call zap.Error in log

### DIFF
--- a/plugin/output/clickhouse/clickhouse.go
+++ b/plugin/output/clickhouse/clickhouse.go
@@ -518,7 +518,7 @@ func (p *Plugin) out(workerData *pipeline.WorkerData, batch *pipeline.Batch) err
 				if !errorLogged {
 					// Log only 1 error per batch to avoid spam.
 					errorLogged = true
-					p.logger.Error("failed to encode value into Clickhouse column, zero value will be used", zap.Error(err),
+					p.logger.Error("failed to encode value into Clickhouse column, zero value will be used",
 						zap.Error(err), zap.String("col", col.Name), zap.String("value", node.AsString()))
 				}
 


### PR DESCRIPTION
# Description

There is already a call to zap.Error in line 522

Fixes # (issue)