### PR TITLE
Join golang dataraces in join_template

### DIFF
--- a/plugin/action/join_template/README.md
+++ b/plugin/action/join_template/README.md
@@ -44,10 +44,4 @@ Enable check without regular expressions.
 
 <br>
 
-**`negate`** *`bool`* 
-
-Inverse continue check to enable end mode.
-
-<br>
-
 <br>*Generated using [__insane-doc__](https://github.com/vitkovskii/insane-doc)*

--- a/plugin/action/join_template/README.md
+++ b/plugin/action/join_template/README.md
@@ -44,4 +44,10 @@ Enable check without regular expressions.
 
 <br>
 
+**`negate`** *`bool`* 
+
+Inverse continue check to enable end mode.
+
+<br>
+
 <br>*Generated using [__insane-doc__](https://github.com/vitkovskii/insane-doc)*

--- a/plugin/action/join_template/README.md
+++ b/plugin/action/join_template/README.md
@@ -34,7 +34,7 @@ Max size of the resulted event. If it is set and the event exceeds the limit, th
 
 **`template`** *`string`* *`required`* 
 
-The name of the template. Available templates: `go_panic`, `cs_exception`.
+The name of the template. Available templates: `go_panic`, `cs_exception`, `go_data_race`.
 
 <br>
 

--- a/plugin/action/join_template/join_template.go
+++ b/plugin/action/join_template/join_template.go
@@ -60,6 +60,11 @@ type Config struct {
 	// >
 	// > Enable check without regular expressions.
 	FastCheck bool `json:"fast_check"` // *
+
+	// > @3@4@5@6
+	// >
+	// > Inverse continue check to enable end mode.
+	Negate bool `json:"negate"` // *
 }
 
 func init() {
@@ -92,6 +97,8 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.ActionPluginP
 
 		StartCheckFunc_:    curTemplate.StartCheck,
 		ContinueCheckFunc_: curTemplate.ContinueCheck,
+
+		Negate: curTemplate.Negate,
 	}
 	p.jp = &join.Plugin{}
 	p.jp.Start(jConfig, params)

--- a/plugin/action/join_template/join_template.go
+++ b/plugin/action/join_template/join_template.go
@@ -53,7 +53,7 @@ type Config struct {
 
 	// > @3@4@5@6
 	// >
-	// > The name of the template. Available templates: `go_panic`, `cs_exception`.
+	// > The name of the template. Available templates: `go_panic`, `cs_exception`, `go_data_race`.
 	Template string `json:"template" required:"true"` // *
 
 	// > @3@4@5@6

--- a/plugin/action/join_template/join_template.go
+++ b/plugin/action/join_template/join_template.go
@@ -60,11 +60,6 @@ type Config struct {
 	// >
 	// > Enable check without regular expressions.
 	FastCheck bool `json:"fast_check"` // *
-
-	// > @3@4@5@6
-	// >
-	// > Inverse continue check to enable end mode.
-	Negate bool `json:"negate"` // *
 }
 
 func init() {

--- a/plugin/action/join_template/join_template_test.go
+++ b/plugin/action/join_template/join_template_test.go
@@ -36,6 +36,13 @@ func TestSimpleJoin(t *testing.T) {
 			iterations:   100,
 			expEvents:    3 * 100,
 		},
+		{
+			name:         "should_ok_for_go_data_race",
+			templateName: "go_data_race",
+			content:      sample.GoDataRace,
+			iterations:   100,
+			expEvents:    3 * 3 * 100,
+		},
 	}
 
 	for _, tt := range cases {

--- a/plugin/action/join_template/sample/go_data_race.txt
+++ b/plugin/action/join_template/sample/go_data_race.txt
@@ -1,0 +1,44 @@
+==================
+WARNING: DATA RACE
+Read at 0x00c000118008 by goroutine 5:
+  main.main.func1()
+      /Users/qwe/base/awesomeProject/main.go:10 +0x38
+
+Previous write at 0x00c000118008 by main goroutine:
+  main.main()
+      /Users/qwe/base/awesomeProject/main.go:15 +0xc0
+
+Goroutine 5 (running) created at:
+  main.main()
+      /Users/qwe/base/awesomeProject/main.go:8 +0x9c
+==================
+# ===next===
+==================
+WARNING: DATA RACE
+Write at 0x00c000118008 by goroutine 5:
+  main.main.func1()
+      /Users/qwe/base/awesomeProject/main.go:10 +0x48
+
+Previous write at 0x00c000118008 by main goroutine:
+  main.main()
+      /Users/qwe/base/awesomeProject/main.go:15 +0xc0
+
+Goroutine 5 (running) created at:
+  main.main()
+      /Users/qwe/base/awesomeProject/main.go:8 +0x9c
+==================
+# ===next===
+==================
+WARNING: DATA RACE
+Read at 0x00c000118008 by main goroutine:
+  main.main()
+      /Users/qwe/base/awesomeProject/main.go:15 +0xb0
+
+Previous write at 0x00c000118008 by goroutine 5:
+  main.main.func1()
+      /Users/qwe/base/awesomeProject/main.go:10 +0x48
+
+Goroutine 5 (running) created at:
+  main.main()
+      /Users/qwe/base/awesomeProject/main.go:8 +0x9c
+==================

--- a/plugin/action/join_template/sample/sample.go
+++ b/plugin/action/join_template/sample/sample.go
@@ -10,3 +10,6 @@ var PanicsWithNilNodes string
 
 //go:embed cs_exception.txt
 var SharpException string
+
+//go:embed go_data_race.txt
+var GoDataRace string

--- a/plugin/action/join_template/template/go_data_race.go
+++ b/plugin/action/join_template/template/go_data_race.go
@@ -1,0 +1,16 @@
+package template
+
+import "strings"
+
+const (
+	goDataRaceStartPrefix  = "WARNING: DATA RACE"
+	goDataRaceFinishPrefix = "=================="
+)
+
+func goDataRaceStartCheck(s string) bool {
+	return strings.HasPrefix(s, goDataRaceStartPrefix)
+}
+
+func goDataRaceFinishCheck(s string) bool {
+	return strings.HasPrefix(s, goDataRaceFinishPrefix)
+}

--- a/plugin/action/join_template/template/go_data_race_test.go
+++ b/plugin/action/join_template/template/go_data_race_test.go
@@ -1,0 +1,1 @@
+package template

--- a/plugin/action/join_template/template/go_data_race_test.go
+++ b/plugin/action/join_template/template/go_data_race_test.go
@@ -110,3 +110,48 @@ func TestGoDataRaceSameResults(t *testing.T) {
 		require.Equal(t, cur.ContinueRe.MatchString(line), goDataRaceFinishCheck(line), line)
 	}
 }
+
+func TestGoDataRaceStartCheck(t *testing.T) {
+	positive := []string{
+		"WARNING: DATA RACE",
+		"WARNING: DATA RACE    ",
+		"WARNING: DATA RACE qwe",
+	}
+
+	negative := []string{
+		"",
+		"qwe",
+		"WARNING",
+		"WARNING: DATA",
+		"  WARNING: DATA RACE",
+	}
+
+	for i, test := range getCases(positive, negative) {
+		require.Equal(t, test.res, goDataRaceStartCheck(test.s), i)
+	}
+}
+
+func TestGoDataRaceFinishCheck(t *testing.T) {
+	prefix := goDataRaceFinishPrefix
+
+	positive := []string{
+		prefix,
+		prefix + "    ",
+		prefix + " qwe",
+	}
+
+	n := len(prefix)
+
+	negative := []string{
+		"",
+		"qwe",
+		prefix[:n-6],
+		prefix[:n-4],
+		prefix[:n-2],
+		"  " + prefix,
+	}
+
+	for i, test := range getCases(positive, negative) {
+		require.Equal(t, test.res, goDataRaceFinishCheck(test.s), i)
+	}
+}

--- a/plugin/action/join_template/template/go_data_race_test.go
+++ b/plugin/action/join_template/template/go_data_race_test.go
@@ -103,7 +103,7 @@ func TestGoDataRaceSameResults(t *testing.T) {
 	cur, err := InitTemplate(nameGoDataRace)
 	require.NoError(t, err)
 
-	lines := getLines(sample.GoDataRace)
+	lines := append(getLines(sample.GoDataRace), getRandLines()...)
 
 	for _, line := range lines {
 		require.Equal(t, cur.StartRe.MatchString(line), goDataRaceStartCheck(line), line)

--- a/plugin/action/join_template/template/go_data_race_test.go
+++ b/plugin/action/join_template/template/go_data_race_test.go
@@ -1,1 +1,112 @@
 package template
+
+import (
+	"testing"
+
+	"github.com/ozontech/file.d/plugin/action/join_template/sample"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkGoDataRaceStartMixedRes(b *testing.B) {
+	cur, err := InitTemplate(nameGoDataRace)
+	require.NoError(b, err)
+
+	lines := getLines(sample.GoDataRace)
+
+	b.ResetTimer()
+	b.Run("explicit", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, line := range lines {
+				goDataRaceStartCheck(line)
+			}
+		}
+	})
+	b.Run("regexp", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, line := range lines {
+				cur.StartRe.MatchString(line)
+			}
+		}
+	})
+}
+
+func BenchmarkGoDataRaceFinishMixedRes(b *testing.B) {
+	cur, err := InitTemplate(nameGoDataRace)
+	require.NoError(b, err)
+
+	lines := getLines(sample.GoDataRace)
+
+	b.ResetTimer()
+	b.Run("explicit", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, line := range lines {
+				goDataRaceFinishCheck(line)
+			}
+		}
+	})
+	b.Run("regexp", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, line := range lines {
+				cur.ContinueRe.MatchString(line)
+			}
+		}
+	})
+}
+
+func BenchmarkGoDataRaceStartNegativeRes(b *testing.B) {
+	cur, err := InitTemplate(nameGoDataRace)
+	require.NoError(b, err)
+
+	lines := getRandLines()
+
+	b.ResetTimer()
+	b.Run("explicit", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, line := range lines {
+				goDataRaceStartCheck(line)
+			}
+		}
+	})
+	b.Run("regexp", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, line := range lines {
+				cur.StartRe.MatchString(line)
+			}
+		}
+	})
+}
+
+func BenchmarkGoDataRaceFinishNegativeRes(b *testing.B) {
+	cur, err := InitTemplate(nameGoDataRace)
+	require.NoError(b, err)
+
+	lines := getRandLines()
+
+	b.ResetTimer()
+	b.Run("explicit", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, line := range lines {
+				goDataRaceFinishCheck(line)
+			}
+		}
+	})
+	b.Run("regexp", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, line := range lines {
+				cur.ContinueRe.MatchString(line)
+			}
+		}
+	})
+}
+
+func TestGoDataRaceSameResults(t *testing.T) {
+	cur, err := InitTemplate(nameGoDataRace)
+	require.NoError(t, err)
+
+	lines := getLines(sample.GoDataRace)
+
+	for _, line := range lines {
+		require.Equal(t, cur.StartRe.MatchString(line), goDataRaceStartCheck(line), line)
+		require.Equal(t, cur.ContinueRe.MatchString(line), goDataRaceFinishCheck(line), line)
+	}
+}

--- a/plugin/action/join_template/template/template.go
+++ b/plugin/action/join_template/template/template.go
@@ -10,6 +10,7 @@ import (
 const (
 	nameGoPanic     = "go_panic"
 	nameCSException = "cs_exception"
+	nameGoDataRace  = "go_data_race"
 )
 
 type joinTemplates map[string]struct {
@@ -18,6 +19,8 @@ type joinTemplates map[string]struct {
 
 	startCheckFunc    func(string) bool
 	continueCheckFunc func(string) bool
+
+	negate bool
 }
 
 var templates = joinTemplates{
@@ -35,6 +38,15 @@ var templates = joinTemplates{
 		startCheckFunc:    sharpStartCheck,
 		continueCheckFunc: sharpContinueCheck,
 	},
+	nameGoDataRace: {
+		startRePat:    `/^WARNING: DATA RACE/`,
+		continueRePat: `/^==================/`,
+
+		startCheckFunc:    goDataRaceStartCheck,
+		continueCheckFunc: goDataRaceFinishCheck,
+
+		negate: true,
+	},
 }
 
 type Template struct {
@@ -42,6 +54,7 @@ type Template struct {
 	ContinueRe    *regexp.Regexp
 	StartCheck    func(string) bool
 	ContinueCheck func(string) bool
+	Negate        bool
 }
 
 func InitTemplate(name string) (Template, error) {
@@ -53,6 +66,7 @@ func InitTemplate(name string) (Template, error) {
 	result := Template{
 		StartCheck:    cur.startCheckFunc,
 		ContinueCheck: cur.continueCheckFunc,
+		Negate:        cur.negate,
 	}
 
 	var err error


### PR DESCRIPTION
Fixes #797

All benchmarks on same input
goos: darwin
goarch: arm64

Go data races:

Mixed results:

Start:
- regex - 1298 ns/op
- explicit - 80 ns/op
- difference is 16 times

Finish:
- regex - 1628 ns/op
- explicit - 83 ns/op
- difference is 20 times

Negative results:

Start:
- regex - 4307 ns/op
- explicit - 211 ns/op
- difference is 20 times

Finish:
- regex - 4198 ns/op
- explicit - 215 ns/op
- difference is 20 times


