### PR TITLE
Dead queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           GOFLAGS: ${{ matrix.flags }}
           LOG_LEVEL: error
         run: |
-          go test -coverprofile=profile${{ matrix.flags }}.out -covermode=atomic -v -coverpkg=./... ./... -json > test-report${{ matrix.flags }}.json
+          go test -coverprofile=profile${{ matrix.flags }}.out -covermode=atomic -v -coverpkg=./... ./... -json | tee test-report${{ matrix.flags }}.json
 
       - name: Coverage report
         run: |
@@ -101,7 +101,7 @@ jobs:
           GOFLAGS: ${{ matrix.flags }}
           LOG_LEVEL: error
         run: |
-          go test ./e2e -coverprofile=profile-e2e${{ matrix.flags }}.out -covermode=atomic -tags=e2e_new -timeout=3m -coverpkg=./... -json > test-report-e2e${{ matrix.flags }}.json
+          go test ./e2e -coverprofile=profile-e2e${{ matrix.flags }}.out -covermode=atomic -tags=e2e_new -timeout=3m -coverpkg=./... -json | tee test-report-e2e${{ matrix.flags }}.json
 
       - name: Coverage report
         run: |

--- a/_sidebar.idoc.md
+++ b/_sidebar.idoc.md
@@ -16,7 +16,7 @@
 @global-contents-table-plugin-input|links-list
   - Action
 @global-contents-table-plugin-action|links-list
-  - Output
+  - [Output](/plugin/output/README.md)
 @global-contents-table-plugin-output|links-list
 
 - **Pipeline**

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -50,7 +50,7 @@
     - [split](plugin/action/split/README.md)
     - [throttle](plugin/action/throttle/README.md)
 
-  - Output
+  - [Output](/plugin/output/README.md)
     - [clickhouse](plugin/output/clickhouse/README.md)
     - [devnull](plugin/output/devnull/README.md)
     - [elasticsearch](plugin/output/elasticsearch/README.md)

--- a/e2e/file_clickhouse/config.yml
+++ b/e2e/file_clickhouse/config.yml
@@ -21,11 +21,59 @@ pipelines:
         override: true
       - type: debug
     output:
+      deadqueue:
+        type: clickhouse
+        addresses:
+          - 127.0.0.1:9001
+        table: test_table_insert
+        insert_timeout: 1m
+        columns:
+          - name: c1
+            type: String
+          - name: c2
+            type: Int8
+          - name: c3
+            type: Int16
+          - name: c4
+            type: Nullable(Int16)
+          - name: c5
+            type: Nullable(String)
+          - name: level
+            type: Enum8('error'=1, 'warn'=2, 'info'=3, 'debug'=4)
+          - name: ipv4
+            type: Nullable(IPv4)
+          - name: ipv6
+            type: Nullable(IPv6)
+          - name: ts
+            type: DateTime
+          - name: ts_with_tz
+            type: DateTime('Europe/Moscow')
+          - name: ts64
+            type: DateTime64(3, 'UTC')
+          - name: ts64_auto
+            type: DateTime64(9, 'UTC')
+          - name: ts_rfc3339nano
+            type: DateTime64(9)
+          - name: f32
+            type: Float32
+          - name: f64
+            type: Float64
+          - name: lc_str
+            type: LowCardinality(String)
+          - name: str_arr
+            type: Array(String)
+          - name: map_str_str
+            type: Map(String,String)
+          - name: uuid
+            type: UUID
+          - name: uuid_nullable
+            type: Nullable(UUID)
       type: clickhouse
       addresses:
         - 127.0.0.1:9001
-      table: test_table_insert
+      table: test_table_insert_not_exists
       insert_timeout: 1m
+      retry: 0
       columns:
         - name: c1
           type: String

--- a/e2e/kafka_auth/docker-compose.yml
+++ b/e2e/kafka_auth/docker-compose.yml
@@ -2,13 +2,16 @@ version: "2.1"
 
 services:
   zookeeper:
-    image: docker.io/bitnami/zookeeper:3.9
+    image: zookeeper:3.9
     ports:
       - "2182:2181"
     volumes:
-      - "zookeeper_data:/bitnami"
+      - "zookeeper_data:/data"
     environment:
-      - ALLOW_ANONYMOUS_LOGIN=yes
+      ZOO_MY_ID: 1
+      ZOO_PORT: 2181
+      ZOO_4LW_COMMANDS_WHITELIST: "*"
+      ZOO_SERVERS: server.1=zookeeper:2888:3888;2181
   init-certs:
       image: docker.io/bitnami/kafka:3.6
       command: /tmp/generate.sh

--- a/e2e/kafka_file/docker-compose.yml
+++ b/e2e/kafka_file/docker-compose.yml
@@ -2,13 +2,16 @@ version: "2"
 
 services:
   zookeeper:
-    image: docker.io/bitnami/zookeeper:3.8
+    image: zookeeper:3.9
     ports:
       - "2181:2181"
     volumes:
-      - "zookeeper_data:/bitnami"
+      - "zookeeper_data:/data"
     environment:
-      - ALLOW_ANONYMOUS_LOGIN=yes
+      ZOO_MY_ID: 1
+      ZOO_PORT: 2181
+      ZOO_4LW_COMMANDS_WHITELIST: "*"
+      ZOO_SERVERS: server.1=zookeeper:2888:3888;2181
   kafka:
     image: docker.io/bitnami/kafka:3.1
     ports:

--- a/fd/file.d.go
+++ b/fd/file.d.go
@@ -269,6 +269,19 @@ func (f *FileD) getStaticInfo(pipelineConfig *cfg.PipelineConfig, pluginKind pip
 			return nil, err
 		}
 
+		deadqueue.Del("type")
+
+		deadqueueConfigJson, err := deadqueue.Encode()
+		if err != nil {
+			logger.Panicf("can't create config json for %s", t)
+		}
+
+		config, err := pipeline.GetConfig(deadqueueInfo, deadqueueConfigJson, values)
+		if err != nil {
+			logger.Fatalf("error on creating %s with type %q: %s", t, pluginKind, err.Error())
+		}
+		deadqueueInfo.Config = config
+
 		// TODO: recursive deadqueue config
 		// deadqueueForDeadqueue := deadqueue.Get("deadqueue").MustMap()
 		configJSON.Del("deadqueue")

--- a/fd/file.d.go
+++ b/fd/file.d.go
@@ -263,7 +263,7 @@ func (f *FileD) getStaticInfo(pipelineConfig *cfg.PipelineConfig, pluginKind pip
 		if len(deadqueueMap) > 0 {
 			deadqueueType := deadqueue.Get("type").MustString()
 			if deadqueueType == "" {
-				return nil, fmt.Errorf("%s doesn't have type", pluginKind)
+				return nil, fmt.Errorf("deadqueue of %s doesn't have type", pluginKind)
 			}
 			deadqueueInfo, err = f.plugins.Get(pluginKind, deadqueueType)
 			if err != nil {
@@ -274,12 +274,12 @@ func (f *FileD) getStaticInfo(pipelineConfig *cfg.PipelineConfig, pluginKind pip
 
 			deadqueueConfigJson, err := deadqueue.Encode()
 			if err != nil {
-				logger.Panicf("can't create config json for %s", t)
+				logger.Panicf("can't create config json for %s deadqueue", deadqueueType)
 			}
 
 			config, err := pipeline.GetConfig(deadqueueInfo, deadqueueConfigJson, values)
 			if err != nil {
-				logger.Fatalf("error on creating %s with type %q: %s", t, pluginKind, err.Error())
+				logger.Fatalf("error on creating deadqueue of %s with type %q: %s", deadqueueType, pluginKind, err.Error())
 			}
 			deadqueueInfo.Config = config
 

--- a/fd/file.d.go
+++ b/fd/file.d.go
@@ -222,10 +222,12 @@ func (f *FileD) setupOutput(p *pipeline.Pipeline, pipelineConfig *cfg.PipelineCo
 		PluginRuntimeInfo: f.instantiatePlugin(info),
 	})
 
-	p.SetDeadQueueOutput(&pipeline.OutputPluginInfo{
-		PluginStaticInfo:  info.DeadQueueInfo,
-		PluginRuntimeInfo: f.instantiatePlugin(info.DeadQueueInfo),
-	})
+	if info.DeadQueueInfo != nil {
+		p.SetDeadQueueOutput(&pipeline.OutputPluginInfo{
+			PluginStaticInfo:  info.DeadQueueInfo,
+			PluginRuntimeInfo: f.instantiatePlugin(info.DeadQueueInfo),
+		})
+	}
 
 	return nil
 }
@@ -254,6 +256,7 @@ func (f *FileD) getStaticInfo(pipelineConfig *cfg.PipelineConfig, pluginKind pip
 	if err != nil {
 		return nil, err
 	}
+
 	deadqueue := configJSON.Get("deadqueue")
 	var deadqueueInfo *pipeline.PluginStaticInfo
 	if deadqueue.MustMap() != nil {
@@ -265,8 +268,12 @@ func (f *FileD) getStaticInfo(pipelineConfig *cfg.PipelineConfig, pluginKind pip
 		if err != nil {
 			return nil, err
 		}
+
+		// TODO: recursive deadqueue config
+		// deadqueueForDeadqueue := deadqueue.Get("deadqueue").MustMap()
 		configJSON.Del("deadqueue")
 	}
+
 	configJson, err := configJSON.Encode()
 	if err != nil {
 		logger.Panicf("can't create config json for %s", t)

--- a/pipeline/backoff.go
+++ b/pipeline/backoff.go
@@ -11,7 +11,7 @@ type RetriableBatcher struct {
 	outFn                RetriableBatcherOutFn
 	batcher              *Batcher
 	backoffOpts          BackoffOpts
-	DeadQueueIsAvailable bool
+	IsDeadQueueAvailable bool
 	onRetryError         func(err error, events []*Event)
 }
 
@@ -21,7 +21,7 @@ type BackoffOpts struct {
 	MinRetention         time.Duration
 	Multiplier           float64
 	AttemptNum           int
-	DeadQueueIsAvailable bool
+	IsDeadQueueAvailable bool
 }
 
 func NewRetriableBatcher(batcherOpts *BatcherOptions, batcherOutFn RetriableBatcherOutFn, opts BackoffOpts, onError func(err error, events []*Event)) *RetriableBatcher {
@@ -29,7 +29,7 @@ func NewRetriableBatcher(batcherOpts *BatcherOptions, batcherOutFn RetriableBatc
 		outFn:                batcherOutFn,
 		backoffOpts:          opts,
 		onRetryError:         onError,
-		DeadQueueIsAvailable: opts.DeadQueueIsAvailable,
+		IsDeadQueueAvailable: opts.IsDeadQueueAvailable,
 	}
 	batcherBackoff.setBatcher(batcherOpts)
 	return batcherBackoff
@@ -66,7 +66,7 @@ func (b *RetriableBatcher) Out(data *WorkerData, batch *Batch) {
 				events = batch.events
 			}
 			b.onRetryError(err, events)
-			if batch != nil && b.DeadQueueIsAvailable {
+			if batch != nil && b.IsDeadQueueAvailable {
 				batch.reset()
 				batch.status = BatchStatusInDeadQueue
 			}

--- a/pipeline/backoff.go
+++ b/pipeline/backoff.go
@@ -11,7 +11,7 @@ type RetriableBatcher struct {
 	outFn                RetriableBatcherOutFn
 	batcher              *Batcher
 	backoffOpts          BackoffOpts
-	IsDeadQueueAvailable bool
+	isDeadQueueAvailable bool
 	onRetryError         func(err error, events []*Event)
 }
 
@@ -29,7 +29,7 @@ func NewRetriableBatcher(batcherOpts *BatcherOptions, batcherOutFn RetriableBatc
 		outFn:                batcherOutFn,
 		backoffOpts:          opts,
 		onRetryError:         onError,
-		IsDeadQueueAvailable: opts.IsDeadQueueAvailable,
+		isDeadQueueAvailable: opts.IsDeadQueueAvailable,
 	}
 	batcherBackoff.setBatcher(batcherOpts)
 	return batcherBackoff
@@ -66,7 +66,7 @@ func (b *RetriableBatcher) Out(data *WorkerData, batch *Batch) {
 				events = batch.events
 			}
 			b.onRetryError(err, events)
-			if batch != nil && b.IsDeadQueueAvailable {
+			if batch != nil && b.isDeadQueueAvailable {
 				batch.reset()
 				batch.status = BatchStatusInDeadQueue
 			}

--- a/pipeline/backoff_test.go
+++ b/pipeline/backoff_test.go
@@ -17,7 +17,7 @@ func TestBackoff(t *testing.T) {
 	eventCount := &atomic.Int32{}
 	eventCountBefore := eventCount.Load()
 
-	errorFn := func(err error) {
+	errorFn := func(err error, events []*Event) {
 		errorCount.Inc()
 	}
 
@@ -42,7 +42,7 @@ func TestBackoff(t *testing.T) {
 func TestBackoffWithError(t *testing.T) {
 	errorCount := &atomic.Int32{}
 	prevValue := errorCount.Load()
-	errorFn := func(err error) {
+	errorFn := func(err error, events []*Event) {
 		errorCount.Inc()
 	}
 

--- a/pipeline/backoff_test.go
+++ b/pipeline/backoff_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/ozontech/file.d/metric"
 	"github.com/prometheus/client_golang/prometheus"
@@ -29,12 +30,17 @@ func TestBackoff(t *testing.T) {
 			eventCount.Inc()
 			return nil
 		},
-		BackoffOpts{AttemptNum: 3},
+		BackoffOpts{
+			AttemptNum:           3,
+			DeadQueueIsAvailable: false,
+		},
 		errorFn,
 	)
 
-	batcherBackoff.Out(nil, nil)
-
+	data := WorkerData(nil)
+	batch := newBatch(1, 1, 1*time.Second)
+	batch.append(&Event{})
+	batcherBackoff.Out(&data, batch)
 	assert.Equal(t, errorCountBefore, errorCount.Load(), "wrong error count")
 	assert.Equal(t, eventCountBefore+1, eventCount.Load(), "wrong event count")
 }
@@ -53,10 +59,48 @@ func TestBackoffWithError(t *testing.T) {
 		func(workerData *WorkerData, batch *Batch) error {
 			return errors.New("some error")
 		},
-		BackoffOpts{AttemptNum: 3},
+		BackoffOpts{
+			AttemptNum:           3,
+			DeadQueueIsAvailable: false,
+		},
 		errorFn,
 	)
 
-	batcherBackoff.Out(nil, nil)
+	data := WorkerData(nil)
+	batch := newBatch(1, 1, 1*time.Second)
+	batch.append(&Event{})
+	batcherBackoff.Out(&data, batch)
 	assert.Equal(t, prevValue+1, errorCount.Load(), "wrong error count")
+	assert.Equal(t, 1, len(batch.events), "wrong number of events in batch")
+	assert.Equal(t, BatchStatusNotReady, batch.status, "wrong batch status")
+}
+
+func TestBackoffWithErrorWithDeadQueue(t *testing.T) {
+	errorCount := &atomic.Int32{}
+	prevValue := errorCount.Load()
+	errorFn := func(err error, events []*Event) {
+		errorCount.Inc()
+	}
+
+	batcherBackoff := NewRetriableBatcher(
+		&BatcherOptions{
+			MetricCtl: metric.NewCtl("", prometheus.NewRegistry()),
+		},
+		func(workerData *WorkerData, batch *Batch) error {
+			return errors.New("some error")
+		},
+		BackoffOpts{
+			AttemptNum:           3,
+			DeadQueueIsAvailable: true,
+		},
+		errorFn,
+	)
+
+	data := WorkerData(nil)
+	batch := newBatch(1, 1, 1*time.Second)
+	batch.append(&Event{})
+	batcherBackoff.Out(&data, batch)
+	assert.Equal(t, prevValue+1, errorCount.Load(), "wrong error count")
+	assert.Equal(t, 0, len(batch.events), "wrong number of events in batch")
+	assert.Equal(t, BatchStatusInDeadQueue, batch.status, "wrong batch status")
 }

--- a/pipeline/backoff_test.go
+++ b/pipeline/backoff_test.go
@@ -32,7 +32,7 @@ func TestBackoff(t *testing.T) {
 		},
 		BackoffOpts{
 			AttemptNum:           3,
-			DeadQueueIsAvailable: false,
+			IsDeadQueueAvailable: false,
 		},
 		errorFn,
 	)
@@ -61,7 +61,7 @@ func TestBackoffWithError(t *testing.T) {
 		},
 		BackoffOpts{
 			AttemptNum:           3,
-			DeadQueueIsAvailable: false,
+			IsDeadQueueAvailable: false,
 		},
 		errorFn,
 	)
@@ -91,7 +91,7 @@ func TestBackoffWithErrorWithDeadQueue(t *testing.T) {
 		},
 		BackoffOpts{
 			AttemptNum:           3,
-			DeadQueueIsAvailable: true,
+			IsDeadQueueAvailable: true,
 		},
 		errorFn,
 	)

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -113,7 +113,7 @@ type Pipeline struct {
 	procCount   *atomic.Int32
 	activeProcs *atomic.Int32
 
-	router *router
+	router *Router
 
 	metricHolder *metric.Holder
 
@@ -198,7 +198,7 @@ func New(name string, settings *Settings, registry *prometheus.Registry, lg *zap
 			PipelineSettings: settings,
 			MetricCtl:        metricCtl,
 		},
-		router: newRouter(),
+		router: NewRouter(),
 		actionMetrics: actionMetrics{
 			m:  make(map[string]*actionMetric),
 			mu: new(sync.RWMutex),
@@ -343,7 +343,7 @@ func (p *Pipeline) Start() {
 	}
 	p.logger.Info("starting output plugin", zap.String("name", p.router.outputInfo.Type))
 
-	p.router.Start(p.router.outputInfo.Config, outputParams)
+	p.router.Start(outputParams)
 
 	p.logger.Info("stating processors", zap.Int("count", len(p.Procs)))
 	for _, processor := range p.Procs {

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -627,6 +627,7 @@ func (p *Pipeline) streamEvent(event *Event) uint64 {
 }
 
 func (p *Pipeline) Commit(event *Event) {
+	p.router.Ack(event)
 	p.finalize(event, true, true)
 }
 

--- a/pipeline/plugin.go
+++ b/pipeline/plugin.go
@@ -77,6 +77,7 @@ type PluginStaticInfo struct {
 	// Every plugin can provide their own API through Endpoints.
 	Endpoints         map[string]func(http.ResponseWriter, *http.Request)
 	AdditionalActions []string // used only for input plugins, defines actions that should be run right after input plugin with input config
+	DeadQueueInfo     *PluginStaticInfo
 }
 
 type PluginRuntimeInfo struct {

--- a/pipeline/plugin.go
+++ b/pipeline/plugin.go
@@ -78,7 +78,8 @@ type PluginStaticInfo struct {
 	// Every plugin can provide their own API through Endpoints.
 	Endpoints         map[string]func(http.ResponseWriter, *http.Request)
 	AdditionalActions []string // used only for input plugins, defines actions that should be run right after input plugin with input config
-	DeadQueueInfo     *PluginStaticInfo
+	// TODO: maybe to OutputPluginStaticInfo cause uses by output and action plugins?
+	DeadQueueInfo *PluginStaticInfo
 }
 
 type PluginRuntimeInfo struct {

--- a/pipeline/plugin.go
+++ b/pipeline/plugin.go
@@ -59,6 +59,7 @@ type ActionPluginParams struct {
 type OutputPluginParams struct {
 	PluginDefaultParams
 	Controller OutputPluginController
+	Router     Router
 	Logger     *zap.SugaredLogger
 }
 

--- a/pipeline/plugin.go
+++ b/pipeline/plugin.go
@@ -59,7 +59,7 @@ type ActionPluginParams struct {
 type OutputPluginParams struct {
 	PluginDefaultParams
 	Controller OutputPluginController
-	Router     Router
+	Router     *Router
 	Logger     *zap.SugaredLogger
 }
 

--- a/pipeline/processor.go
+++ b/pipeline/processor.go
@@ -55,7 +55,7 @@ func allEventStatuses() []eventStatus {
 type processor struct {
 	id       int
 	streamer *streamer
-	router   router
+	router   Router
 	finalize finalizeFn
 
 	activeCounter *atomic.Int32
@@ -78,7 +78,7 @@ func newProcessor(
 	id int,
 	actionMetrics *actionMetrics,
 	activeCounter *atomic.Int32,
-	router *router,
+	router *Router,
 	streamer *streamer,
 	finalizeFn finalizeFn,
 	incMaxEventSizeExceededFn func(lvs ...string),

--- a/pipeline/processor.go
+++ b/pipeline/processor.go
@@ -55,7 +55,7 @@ func allEventStatuses() []eventStatus {
 type processor struct {
 	id       int
 	streamer *streamer
-	router   Router
+	router   *Router
 	finalize finalizeFn
 
 	activeCounter *atomic.Int32
@@ -88,7 +88,7 @@ func newProcessor(
 		id:            id,
 		streamer:      streamer,
 		actionMetrics: actionMetrics,
-		router:        *router,
+		router:        router,
 		finalize:      finalizeFn,
 
 		activeCounter: activeCounter,

--- a/pipeline/processor.go
+++ b/pipeline/processor.go
@@ -55,7 +55,7 @@ func allEventStatuses() []eventStatus {
 type processor struct {
 	id       int
 	streamer *streamer
-	output   OutputPlugin
+	router   router
 	finalize finalizeFn
 
 	activeCounter *atomic.Int32
@@ -78,7 +78,7 @@ func newProcessor(
 	id int,
 	actionMetrics *actionMetrics,
 	activeCounter *atomic.Int32,
-	output OutputPlugin,
+	router *router,
 	streamer *streamer,
 	finalizeFn finalizeFn,
 	incMaxEventSizeExceededFn func(lvs ...string),
@@ -88,7 +88,7 @@ func newProcessor(
 		id:            id,
 		streamer:      streamer,
 		actionMetrics: actionMetrics,
-		output:        output,
+		router:        *router,
 		finalize:      finalizeFn,
 
 		activeCounter: activeCounter,
@@ -153,7 +153,7 @@ func (p *processor) processSequence(event *Event) bool {
 		}
 
 		event.stage = eventStageOutput
-		p.output.Out(event)
+		p.router.Out(event)
 	}
 
 	return true
@@ -447,7 +447,7 @@ func (p *processor) Spawn(parent *Event, nodes []*insaneJSON.Node) {
 		ok, _ := p.doActions(child)
 		if ok {
 			child.stage = eventStageOutput
-			p.output.Out(child)
+			p.router.Out(child)
 		}
 	}
 

--- a/pipeline/router.go
+++ b/pipeline/router.go
@@ -38,6 +38,10 @@ func (r *Router) Stop() {
 	r.output.Stop()
 }
 
+func (r *Router) DeadQueueIsAvailable() bool {
+	return r.deadQueue != nil
+}
+
 func (r *Router) Start(params *OutputPluginParams) {
 	params.Router = *r
 	r.output.Start(r.outputInfo.Config, params)

--- a/pipeline/router.go
+++ b/pipeline/router.go
@@ -1,32 +1,45 @@
 package pipeline
 
-type router struct {
+type Router struct {
 	output     OutputPlugin
-	deadQueue  OutputPlugin
 	outputInfo *OutputPluginInfo
+
+	deadQueue     OutputPlugin
+	deadQueueInfo *OutputPluginInfo
 }
 
-func newRouter() *router {
-	return &router{}
+func NewRouter() *Router {
+	return &Router{}
 }
 
-func (r *router) SetOutput(info *OutputPluginInfo) {
+func (r *Router) SetOutput(info *OutputPluginInfo) {
 	r.outputInfo = info
 	r.output = info.Plugin.(OutputPlugin)
 }
 
-func (r *router) SetDeadQueueOutput(info *OutputPluginInfo) {
+func (r *Router) SetDeadQueueOutput(info *OutputPluginInfo) {
+	r.deadQueueInfo = info
 	r.deadQueue = info.Plugin.(OutputPlugin)
 }
 
-func (p *router) Out(event *Event) {
-	p.output.Out(event)
+func (r *Router) Ack(event *Event) {
+
 }
 
-func (p *router) Stop() {
-	p.output.Stop()
+func (r *Router) Fail(event *Event) {
+	r.deadQueue.Out(event)
 }
 
-func (p *router) Start(config AnyConfig, params *OutputPluginParams) {
-	p.output.Start(config, params)
+func (r *Router) Out(event *Event) {
+	r.output.Out(event)
+}
+
+func (r *Router) Stop() {
+	r.output.Stop()
+}
+
+func (r *Router) Start(params *OutputPluginParams) {
+	params.Router = *r
+	r.output.Start(r.outputInfo.Config, params)
+	r.deadQueue.Start(r.deadQueueInfo.Config, params)
 }

--- a/pipeline/router.go
+++ b/pipeline/router.go
@@ -1,0 +1,32 @@
+package pipeline
+
+type router struct {
+	output     OutputPlugin
+	deadQueue  OutputPlugin
+	outputInfo *OutputPluginInfo
+}
+
+func newRouter() *router {
+	return &router{}
+}
+
+func (r *router) SetOutput(info *OutputPluginInfo) {
+	r.outputInfo = info
+	r.output = info.Plugin.(OutputPlugin)
+}
+
+func (r *router) SetDeadQueueOutput(info *OutputPluginInfo) {
+	r.deadQueue = info.Plugin.(OutputPlugin)
+}
+
+func (p *router) Out(event *Event) {
+	p.output.Out(event)
+}
+
+func (p *router) Stop() {
+	p.output.Stop()
+}
+
+func (p *router) Start(config AnyConfig, params *OutputPluginParams) {
+	p.output.Start(config, params)
+}

--- a/pipeline/router.go
+++ b/pipeline/router.go
@@ -23,7 +23,7 @@ func (r *Router) SetDeadQueueOutput(info *OutputPluginInfo) {
 }
 
 func (r *Router) Ack(event *Event) {
-
+	// TODO: send commit to input after receiving all acks from outputs
 }
 
 func (r *Router) Fail(event *Event) {

--- a/pipeline/router.go
+++ b/pipeline/router.go
@@ -27,7 +27,7 @@ func (r *Router) Ack(event *Event) {
 }
 
 func (r *Router) Fail(event *Event) {
-	if r.DeadQueueIsAvailable() {
+	if r.IsDeadQueueAvailable() {
 		r.deadQueue.Out(event)
 	}
 }
@@ -38,19 +38,19 @@ func (r *Router) Out(event *Event) {
 
 func (r *Router) Stop() {
 	r.output.Stop()
-	if r.DeadQueueIsAvailable() {
+	if r.IsDeadQueueAvailable() {
 		r.deadQueue.Stop()
 	}
 }
 
-func (r *Router) DeadQueueIsAvailable() bool {
+func (r *Router) IsDeadQueueAvailable() bool {
 	return r.deadQueue != nil
 }
 
 func (r *Router) Start(params *OutputPluginParams) {
-	params.Router = *r
+	params.Router = r
 	r.output.Start(r.outputInfo.Config, params)
-	if r.DeadQueueIsAvailable() {
+	if r.IsDeadQueueAvailable() {
 		r.deadQueue.Start(r.deadQueueInfo.Config, params)
 	}
 }

--- a/pipeline/router.go
+++ b/pipeline/router.go
@@ -27,7 +27,9 @@ func (r *Router) Ack(event *Event) {
 }
 
 func (r *Router) Fail(event *Event) {
-	r.deadQueue.Out(event)
+	if r.DeadQueueIsAvailable() {
+		r.deadQueue.Out(event)
+	}
 }
 
 func (r *Router) Out(event *Event) {
@@ -36,6 +38,9 @@ func (r *Router) Out(event *Event) {
 
 func (r *Router) Stop() {
 	r.output.Stop()
+	if r.DeadQueueIsAvailable() {
+		r.deadQueue.Stop()
+	}
 }
 
 func (r *Router) DeadQueueIsAvailable() bool {
@@ -45,5 +50,7 @@ func (r *Router) DeadQueueIsAvailable() bool {
 func (r *Router) Start(params *OutputPluginParams) {
 	params.Router = *r
 	r.output.Start(r.outputInfo.Config, params)
-	r.deadQueue.Start(r.deadQueueInfo.Config, params)
+	if r.DeadQueueIsAvailable() {
+		r.deadQueue.Start(r.deadQueueInfo.Config, params)
+	}
 }

--- a/pipeline/router_test.go
+++ b/pipeline/router_test.go
@@ -72,7 +72,7 @@ func TestRouterNormalProcessing(t *testing.T) {
 
 	params := test.NewEmptyOutputPluginParams()
 	params.PipelineName = "test_pipeline"
-	params.Router = *r
+	params.Router = r
 	params.Controller = controller
 	r.Start(params)
 	defer r.Stop()
@@ -122,7 +122,7 @@ func TestRouterDeadQueueProcessing(t *testing.T) {
 
 	params := test.NewEmptyOutputPluginParams()
 	params.PipelineName = "test_pipeline"
-	params.Router = *r
+	params.Router = r
 	params.Controller = controller
 	r.Start(params)
 	defer r.Stop()

--- a/pipeline/router_test.go
+++ b/pipeline/router_test.go
@@ -1,0 +1,160 @@
+package pipeline_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ozontech/file.d/pipeline"
+	"github.com/ozontech/file.d/plugin/output/devnull"
+	"github.com/ozontech/file.d/test"
+	insaneJSON "github.com/ozontech/insane-json"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/atomic"
+)
+
+type fakeOutputPluginController struct {
+	mu      sync.Mutex
+	commits []*pipeline.Event
+	errors  []string
+}
+
+func (f *fakeOutputPluginController) Commit(event *pipeline.Event) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.commits = append(f.commits, event)
+}
+func (f *fakeOutputPluginController) Error(err string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.errors = append(f.errors, err)
+}
+
+func (f *fakeOutputPluginController) getCommits() []*pipeline.Event {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.commits
+}
+
+func (f *fakeOutputPluginController) getErrors() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.errors
+}
+
+func TestRouterNormalProcessing(t *testing.T) {
+	t.Parallel()
+
+	r := pipeline.NewRouter()
+	controller := &fakeOutputPluginController{}
+
+	// Setup main output that succeeds
+	var outputCount atomic.Int32
+	outputPlugin, outputConfig := createDevNullPlugin(func(event *pipeline.Event) {
+		outputCount.Add(1)
+	})
+
+	r.SetOutput(&pipeline.OutputPluginInfo{
+		PluginStaticInfo:  &pipeline.PluginStaticInfo{Config: outputConfig},
+		PluginRuntimeInfo: &pipeline.PluginRuntimeInfo{Plugin: outputPlugin},
+	})
+
+	// Setup dead queue that shouldn't be used
+	var deadQueueCount atomic.Int32
+	deadQueuePlugin, deadQueueConfig := createDevNullPlugin(func(event *pipeline.Event) {
+		deadQueueCount.Add(1)
+	})
+
+	r.SetDeadQueueOutput(&pipeline.OutputPluginInfo{
+		PluginStaticInfo:  &pipeline.PluginStaticInfo{Config: deadQueueConfig},
+		PluginRuntimeInfo: &pipeline.PluginRuntimeInfo{Plugin: deadQueuePlugin},
+	})
+
+	params := test.NewEmptyOutputPluginParams()
+	params.PipelineName = "test_pipeline"
+	params.Router = *r
+	params.Controller = controller
+	r.Start(params)
+	defer r.Stop()
+
+	// Send test event
+	event := newEvent(t)
+	r.Out(event)
+
+	// Wait for processing
+	assert.Eventually(t, func() bool {
+		return outputCount.Load() == 1
+	}, 100*time.Millisecond, 10*time.Millisecond, "event should be processed")
+
+	assert.Equal(t, int32(0), deadQueueCount.Load(), "dead queue should not be used")
+	assert.Len(t, controller.getCommits(), 1, "should commit successful event")
+	assert.Empty(t, controller.getErrors(), "should not produce errors")
+}
+
+func TestRouterDeadQueueProcessing(t *testing.T) {
+	t.Parallel()
+
+	r := pipeline.NewRouter()
+	controller := &fakeOutputPluginController{}
+
+	// Setup main output that fails
+	var outputCount atomic.Int32
+	outputPlugin, outputConfig := createDevNullPlugin(func(event *pipeline.Event) {
+		outputCount.Add(1)
+		r.Fail(event)
+	})
+
+	r.SetOutput(&pipeline.OutputPluginInfo{
+		PluginStaticInfo:  &pipeline.PluginStaticInfo{Config: outputConfig},
+		PluginRuntimeInfo: &pipeline.PluginRuntimeInfo{Plugin: outputPlugin},
+	})
+
+	// Setup dead queue
+	var deadQueueCount atomic.Int32
+	deadQueuePlugin, deadQueueConfig := createDevNullPlugin(func(event *pipeline.Event) {
+		deadQueueCount.Add(1)
+	})
+
+	r.SetDeadQueueOutput(&pipeline.OutputPluginInfo{
+		PluginStaticInfo:  &pipeline.PluginStaticInfo{Config: deadQueueConfig},
+		PluginRuntimeInfo: &pipeline.PluginRuntimeInfo{Plugin: deadQueuePlugin},
+	})
+
+	params := test.NewEmptyOutputPluginParams()
+	params.PipelineName = "test_pipeline"
+	params.Router = *r
+	params.Controller = controller
+	r.Start(params)
+	defer r.Stop()
+
+	// Send test event
+	event := newEvent(t)
+	r.Out(event)
+
+	// Wait for processing
+	assert.Eventually(t, func() bool {
+		return deadQueueCount.Load() == 1
+	}, 100*time.Millisecond, 10*time.Millisecond, "event should go to dead queue")
+
+	assert.Equal(t, int32(1), outputCount.Load(), "main output should try to process")
+	assert.Len(t, controller.getCommits(), 2, "should commit successful event")
+	assert.Empty(t, controller.getErrors(), "should not produce errors")
+}
+
+func createDevNullPlugin(outFn func(event *pipeline.Event)) (*devnull.Plugin, pipeline.AnyConfig) {
+	plugin, config := devnull.Factory()
+	p := plugin.(*devnull.Plugin)
+	p.SetOutFn(outFn)
+	return p, config
+}
+
+func newEvent(t *testing.T) *pipeline.Event {
+	root, err := insaneJSON.DecodeString(`{}`)
+	if err != nil {
+		t.Skip() // ignore invalid input
+	}
+	return &pipeline.Event{
+		Root: root,
+		Buf:  make([]byte, 0, 1024),
+	}
+}

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -764,6 +764,8 @@ It sends the event batches to Clickhouse database using
 
 File.d uses low level Go client - [ch-go](https://github.com/ClickHouse/ch-go) to provide these features.
 
+Supports [dead queue](/plugin/output/README.md#dead-queue).
+
 [More details...](plugin/output/clickhouse/README.md)
 ## devnull
 It provides an API to test pipelines and other plugins.
@@ -772,6 +774,8 @@ It provides an API to test pipelines and other plugins.
 ## elasticsearch
 It sends events into Elasticsearch. It uses `_bulk` API to send events in batches.
 If a network error occurs, the batch will infinitely try to be delivered to the random endpoint.
+
+Supports [dead queue](/plugin/output/README.md#dead-queue).
 
 [More details...](plugin/output/elasticsearch/README.md)
 ## file
@@ -796,17 +800,25 @@ GELF messages are separated by null byte. Each message is a JSON with the follow
 Every field with an underscore prefix `_` will be treated as an extra field.
 Allowed characters in field names are letters, numbers, underscores, dashes, and dots.
 
+Supports [dead queue](/plugin/output/README.md#dead-queue).
+
 [More details...](plugin/output/gelf/README.md)
 ## kafka
 It sends the event batches to kafka brokers using `franz-go` lib.
+
+Supports [dead queue](/plugin/output/README.md#dead-queue).
 
 [More details...](plugin/output/kafka/README.md)
 ## loki
 It sends the logs batches to Loki using HTTP API.
 
+Supports [dead queue](/plugin/output/README.md#dead-queue).
+
 [More details...](plugin/output/loki/README.md)
 ## postgres
 It sends the event batches to postgres db using pgx.
+
+Supports [dead queue](/plugin/output/README.md#dead-queue).
 
 [More details...](plugin/output/postgres/README.md)
 ## s3
@@ -935,6 +947,8 @@ Out:
   }
 }
 ```
+
+Supports [dead queue](/plugin/output/README.md#dead-queue).
 
 [More details...](plugin/output/splunk/README.md)
 ## stdout

--- a/plugin/output/README.idoc.md
+++ b/plugin/output/README.idoc.md
@@ -1,3 +1,74 @@
 # Output plugins
 
 @global-contents-table-plugin-output|contents-table
+
+## dead queue
+
+Failed events from the main pipeline are redirected to a dead-letter queue (DLQ) to prevent data loss and enable recovery.
+
+### Examples
+
+#### Dead queue to the reserve elasticsearch
+
+Consumes logs from a Kafka topic. Sends them to Elasticsearch (primary cluster). Fails over to a reserve ("dead-letter") Elasticsearch if the primary is unavailable.
+
+```yaml
+main_pipeline:
+  input:
+    type: kafka
+    brokers:
+      - kafka:9092
+    topics:
+      - logs
+  output:
+    type: elasticsearch
+    workers_count: 32
+    endpoints:
+      - http://elasticsearch-primary:9200
+    # route to reserve elasticsearch
+    deadqueue:
+      endpoints:
+        - http://elasticsearch-reserve:9200
+      type: elasticsearch
+```
+
+#### Dead queue with second kafka topic and low priority consumer
+
+Main Pipeline: Processes logs from Kafka → Elasticsearch. Failed events go to a dead-letter Kafka topic.
+
+Dead-Queue Pipeline: Re-processes failed events from the DLQ topic with lower priority.
+
+```yaml
+main_pipeline:
+  input:
+    type: kafka
+    brokers:
+      - kafka:9092
+    topics:
+      - logs
+  output:
+    type: elasticsearch
+    workers_count: 32
+    endpoints:
+      - http://elasticsearch:9200
+    # route to deadqueue pipeline
+    deadqueue:
+      brokers:
+      - kafka:9092
+      default_topic: logs-deadqueue
+      type: kafka
+
+deadqueue_pipeline:
+  input:
+    type: kafka
+    brokers:
+      - kafka:9092
+    topics:
+      - logs-deadqueue
+  output:
+    type: elasticsearch
+    workers_count: 1 # low priority
+    fatal_on_failed_insert: false
+    endpoints:
+      - http://elasticsearch:9200
+```

--- a/plugin/output/README.md
+++ b/plugin/output/README.md
@@ -7,6 +7,8 @@ It sends the event batches to Clickhouse database using
 
 File.d uses low level Go client - [ch-go](https://github.com/ClickHouse/ch-go) to provide these features.
 
+Supports [dead queue](/plugin/output/README.md#dead-queue).
+
 [More details...](plugin/output/clickhouse/README.md)
 ## devnull
 It provides an API to test pipelines and other plugins.
@@ -15,6 +17,8 @@ It provides an API to test pipelines and other plugins.
 ## elasticsearch
 It sends events into Elasticsearch. It uses `_bulk` API to send events in batches.
 If a network error occurs, the batch will infinitely try to be delivered to the random endpoint.
+
+Supports [dead queue](/plugin/output/README.md#dead-queue).
 
 [More details...](plugin/output/elasticsearch/README.md)
 ## file
@@ -39,17 +43,25 @@ GELF messages are separated by null byte. Each message is a JSON with the follow
 Every field with an underscore prefix `_` will be treated as an extra field.
 Allowed characters in field names are letters, numbers, underscores, dashes, and dots.
 
+Supports [dead queue](/plugin/output/README.md#dead-queue).
+
 [More details...](plugin/output/gelf/README.md)
 ## kafka
 It sends the event batches to kafka brokers using `franz-go` lib.
+
+Supports [dead queue](/plugin/output/README.md#dead-queue).
 
 [More details...](plugin/output/kafka/README.md)
 ## loki
 It sends the logs batches to Loki using HTTP API.
 
+Supports [dead queue](/plugin/output/README.md#dead-queue).
+
 [More details...](plugin/output/loki/README.md)
 ## postgres
 It sends the event batches to postgres db using pgx.
+
+Supports [dead queue](/plugin/output/README.md#dead-queue).
 
 [More details...](plugin/output/postgres/README.md)
 ## s3
@@ -179,9 +191,82 @@ Out:
 }
 ```
 
+Supports [dead queue](/plugin/output/README.md#dead-queue).
+
 [More details...](plugin/output/splunk/README.md)
 ## stdout
 It writes events to stdout(also known as console).
 
 [More details...](plugin/output/stdout/README.md)
+
+## dead queue
+
+Failed events from the main pipeline are redirected to a dead-letter queue (DLQ) to prevent data loss and enable recovery.
+
+### Examples
+
+#### Dead queue to the reserve elasticsearch
+
+Consumes logs from a Kafka topic. Sends them to Elasticsearch (primary cluster). Fails over to a reserve ("dead-letter") Elasticsearch if the primary is unavailable.
+
+```yaml
+main_pipeline:
+  input:
+    type: kafka
+    brokers:
+      - kafka:9092
+    topics:
+      - logs
+  output:
+    type: elasticsearch
+    workers_count: 32
+    endpoints:
+      - http://elasticsearch-primary:9200
+    # route to reserve elasticsearch
+    deadqueue:
+      endpoints:
+        - http://elasticsearch-reserve:9200
+      type: elasticsearch
+```
+
+#### Dead queue with second kafka topic and low priority consumer
+
+Main Pipeline: Processes logs from Kafka → Elasticsearch. Failed events go to a dead-letter Kafka topic.
+
+Dead-Queue Pipeline: Re-processes failed events from the DLQ topic with lower priority.
+
+```yaml
+main_pipeline:
+  input:
+    type: kafka
+    brokers:
+      - kafka:9092
+    topics:
+      - logs
+  output:
+    type: elasticsearch
+    workers_count: 32
+    endpoints:
+      - http://elasticsearch:9200
+    # route to deadqueue pipeline
+    deadqueue:
+      brokers:
+      - kafka:9092
+      default_topic: logs-deadqueue
+      type: kafka
+
+deadqueue_pipeline:
+  input:
+    type: kafka
+    brokers:
+      - kafka:9092
+    topics:
+      - logs-deadqueue
+  output:
+    type: elasticsearch
+    workers_count: 1 # low priority
+    fatal_on_failed_insert: false
+    endpoints:
+      - http://elasticsearch:9200
+```
 <br>*Generated using [__insane-doc__](https://github.com/vitkovskii/insane-doc)*

--- a/plugin/output/clickhouse/README.md
+++ b/plugin/output/clickhouse/README.md
@@ -5,6 +5,8 @@ It sends the event batches to Clickhouse database using
 
 File.d uses low level Go client - [ch-go](https://github.com/ClickHouse/ch-go) to provide these features.
 
+Supports [dead queue](/plugin/output/README.md#dead-queue).
+
 ### Config params
 **`addresses`** *`[]Address`* *`required`* 
 
@@ -128,8 +130,7 @@ File.d will fall with non-zero exit code or skip message (see fatal_on_failed_in
 
 **`fatal_on_failed_insert`** *`bool`* *`default=false`* 
 
-After an insert error, fall with a non-zero exit code or not
-**Experimental feature**
+After an insert error, fall with a non-zero exit code or not. A configured deadqueue disables fatal exits.
 
 <br>
 

--- a/plugin/output/clickhouse/clickhouse.go
+++ b/plugin/output/clickhouse/clickhouse.go
@@ -59,7 +59,7 @@ type Plugin struct {
 	insertErrorsMetric prometheus.Counter
 	queriesCountMetric prometheus.Counter
 
-	router pipeline.Router
+	router *pipeline.Router
 }
 
 type Setting struct {
@@ -444,12 +444,12 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.OutputPluginP
 		MinRetention:         p.config.Retention_,
 		Multiplier:           float64(p.config.RetentionExponentMultiplier),
 		AttemptNum:           p.config.Retry,
-		DeadQueueIsAvailable: p.router.DeadQueueIsAvailable(),
+		IsDeadQueueAvailable: p.router.IsDeadQueueAvailable(),
 	}
 
 	onError := func(err error, events []*pipeline.Event) {
 		var level zapcore.Level
-		if p.config.FatalOnFailedInsert && !p.router.DeadQueueIsAvailable() {
+		if p.config.FatalOnFailedInsert && !p.router.IsDeadQueueAvailable() {
 			level = zapcore.FatalLevel
 		} else {
 			level = zapcore.ErrorLevel

--- a/plugin/output/clickhouse/clickhouse.go
+++ b/plugin/output/clickhouse/clickhouse.go
@@ -443,7 +443,7 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.OutputPluginP
 		AttemptNum:   p.config.Retry,
 	}
 
-	onError := func(err error) {
+	onError := func(err error, _ []*pipeline.Event) {
 		var level zapcore.Level
 		if p.config.FatalOnFailedInsert {
 			level = zapcore.FatalLevel

--- a/plugin/output/clickhouse/clickhouse.go
+++ b/plugin/output/clickhouse/clickhouse.go
@@ -58,6 +58,8 @@ type Plugin struct {
 	// plugin metrics
 	insertErrorsMetric prometheus.Counter
 	queriesCountMetric prometheus.Counter
+
+	router pipeline.Router
 }
 
 type Setting struct {
@@ -437,15 +439,17 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.OutputPluginP
 		MetricCtl:      params.MetricCtl,
 	}
 
+	p.router = params.Router
 	backoffOpts := pipeline.BackoffOpts{
-		MinRetention: p.config.Retention_,
-		Multiplier:   float64(p.config.RetentionExponentMultiplier),
-		AttemptNum:   p.config.Retry,
+		MinRetention:         p.config.Retention_,
+		Multiplier:           float64(p.config.RetentionExponentMultiplier),
+		AttemptNum:           p.config.Retry,
+		DeadQueueIsAvailable: p.router.DeadQueueIsAvailable(),
 	}
 
-	onError := func(err error, _ []*pipeline.Event) {
+	onError := func(err error, events []*pipeline.Event) {
 		var level zapcore.Level
-		if p.config.FatalOnFailedInsert {
+		if p.config.FatalOnFailedInsert && !p.router.DeadQueueIsAvailable() {
 			level = zapcore.FatalLevel
 		} else {
 			level = zapcore.ErrorLevel
@@ -454,6 +458,10 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.OutputPluginP
 		p.logger.Log(level, "can't insert to the table", zap.Error(err),
 			zap.Int("retries", p.config.Retry),
 			zap.String("table", p.config.Table))
+
+		for i := range events {
+			p.router.Fail(events[i])
+		}
 	}
 
 	p.batcher = pipeline.NewRetriableBatcher(

--- a/plugin/output/clickhouse/clickhouse.go
+++ b/plugin/output/clickhouse/clickhouse.go
@@ -30,6 +30,8 @@ It sends the event batches to Clickhouse database using
 [Native protocol](https://clickhouse.com/docs/en/interfaces/tcp/).
 
 File.d uses low level Go client - [ch-go](https://github.com/ClickHouse/ch-go) to provide these features.
+
+Supports [dead queue](/plugin/output/README.md#dead-queue).
 }*/
 
 const (
@@ -247,8 +249,7 @@ type Config struct {
 
 	// > @3@4@5@6
 	// >
-	// > After an insert error, fall with a non-zero exit code or not
-	// > **Experimental feature**
+	// > After an insert error, fall with a non-zero exit code or not. A configured deadqueue disables fatal exits.
 	FatalOnFailedInsert bool `json:"fatal_on_failed_insert" default:"false"` // *
 
 	// > @3@4@5@6

--- a/plugin/output/devnull/devnull.go
+++ b/plugin/output/devnull/devnull.go
@@ -12,7 +12,7 @@ It provides an API to test pipelines and other plugins.
 
 type Plugin struct {
 	controller pipeline.OutputPluginController
-	router     pipeline.Router
+	router     *pipeline.Router
 	outFn      func(event *pipeline.Event)
 	total      *atomic.Int64
 }

--- a/plugin/output/devnull/devnull.go
+++ b/plugin/output/devnull/devnull.go
@@ -12,6 +12,7 @@ It provides an API to test pipelines and other plugins.
 
 type Plugin struct {
 	controller pipeline.OutputPluginController
+	router     pipeline.Router
 	outFn      func(event *pipeline.Event)
 	total      *atomic.Int64
 }
@@ -31,6 +32,7 @@ func Factory() (pipeline.AnyPlugin, pipeline.AnyConfig) {
 
 func (p *Plugin) Start(_ pipeline.AnyConfig, params *pipeline.OutputPluginParams) {
 	p.controller = params.Controller
+	p.router = params.Router
 	p.total = &atomic.Int64{}
 }
 

--- a/plugin/output/elasticsearch/README.md
+++ b/plugin/output/elasticsearch/README.md
@@ -2,6 +2,8 @@
 It sends events into Elasticsearch. It uses `_bulk` API to send events in batches.
 If a network error occurs, the batch will infinitely try to be delivered to the random endpoint.
 
+Supports [dead queue](/plugin/output/README.md#dead-queue).
+
 ### Config params
 **`endpoints`** *`[]string`* *`required`* 
 
@@ -128,8 +130,7 @@ File.d will fall with non-zero exit code or skip message (see fatal_on_failed_in
 
 **`fatal_on_failed_insert`** *`bool`* *`default=false`* 
 
-After an insert error, fall with a non-zero exit code or not
-**Experimental feature**
+After an insert error, fall with a non-zero exit code or not. A configured deadqueue disables fatal exits.
 
 <br>
 

--- a/plugin/output/elasticsearch/elasticsearch.go
+++ b/plugin/output/elasticsearch/elasticsearch.go
@@ -51,7 +51,7 @@ type Plugin struct {
 	sendErrorMetric      *prometheus.CounterVec
 	indexingErrorsMetric prometheus.Counter
 
-	router pipeline.Router
+	router *pipeline.Router
 }
 
 // ! config-params
@@ -263,12 +263,12 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.OutputPluginP
 		MinRetention:         p.config.Retention_,
 		Multiplier:           float64(p.config.RetentionExponentMultiplier),
 		AttemptNum:           p.config.Retry,
-		DeadQueueIsAvailable: p.router.DeadQueueIsAvailable(),
+		IsDeadQueueAvailable: p.router.IsDeadQueueAvailable(),
 	}
 
 	onError := func(err error, events []*pipeline.Event) {
 		var level zapcore.Level
-		if p.config.FatalOnFailedInsert && !p.router.DeadQueueIsAvailable() {
+		if p.config.FatalOnFailedInsert && !p.router.IsDeadQueueAvailable() {
 			level = zapcore.FatalLevel
 		} else {
 			level = zapcore.ErrorLevel

--- a/plugin/output/elasticsearch/elasticsearch.go
+++ b/plugin/output/elasticsearch/elasticsearch.go
@@ -262,7 +262,7 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.OutputPluginP
 		AttemptNum:   p.config.Retry,
 	}
 
-	onError := func(err error) {
+	onError := func(err error, _ []*pipeline.Event) {
 		var level zapcore.Level
 		if p.config.FatalOnFailedInsert {
 			level = zapcore.FatalLevel

--- a/plugin/output/elasticsearch/elasticsearch.go
+++ b/plugin/output/elasticsearch/elasticsearch.go
@@ -23,6 +23,8 @@ import (
 /*{ introduction
 It sends events into Elasticsearch. It uses `_bulk` API to send events in batches.
 If a network error occurs, the batch will infinitely try to be delivered to the random endpoint.
+
+Supports [dead queue](/plugin/output/README.md#dead-queue).
 }*/
 
 const (
@@ -169,8 +171,7 @@ type Config struct {
 
 	// > @3@4@5@6
 	// >
-	// > After an insert error, fall with a non-zero exit code or not
-	// > **Experimental feature**
+	// > After an insert error, fall with a non-zero exit code or not. A configured deadqueue disables fatal exits.
 	FatalOnFailedInsert bool `json:"fatal_on_failed_insert" default:"false"` // *
 
 	// > @3@4@5@6

--- a/plugin/output/gelf/README.md
+++ b/plugin/output/gelf/README.md
@@ -16,6 +16,8 @@ GELF messages are separated by null byte. Each message is a JSON with the follow
 Every field with an underscore prefix `_` will be treated as an extra field.
 Allowed characters in field names are letters, numbers, underscores, dashes, and dots.
 
+Supports [dead queue](/plugin/output/README.md#dead-queue).
+
 ### Config params
 **`endpoint`** *`string`* *`required`* 
 
@@ -121,8 +123,7 @@ After this timeout the batch will be sent even if batch isn't completed.
 
 **`retry`** *`int`* *`default=0`* 
 
-Retries of insertion. If File.d cannot insert for this number of attempts,
-File.d will fall with non-zero exit code or skip message (see fatal_on_failed_insert).
+After an insert error, fall with a non-zero exit code or not. A configured deadqueue disables fatal exits.
 
 <br>
 

--- a/plugin/output/gelf/gelf.go
+++ b/plugin/output/gelf/gelf.go
@@ -236,7 +236,7 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.OutputPluginP
 		AttemptNum:   p.config.Retry,
 	}
 
-	onError := func(err error) {
+	onError := func(err error, _ []*pipeline.Event) {
 		var level zapcore.Level
 		if p.config.FatalOnFailedInsert {
 			level = zapcore.FatalLevel

--- a/plugin/output/gelf/gelf.go
+++ b/plugin/output/gelf/gelf.go
@@ -33,6 +33,8 @@ GELF messages are separated by null byte. Each message is a JSON with the follow
 
 Every field with an underscore prefix `_` will be treated as an extra field.
 Allowed characters in field names are letters, numbers, underscores, dashes, and dots.
+
+Supports [dead queue](/plugin/output/README.md#dead-queue).
 }*/
 
 const (
@@ -151,8 +153,7 @@ type Config struct {
 
 	// > @3@4@5@6
 	// >
-	// > Retries of insertion. If File.d cannot insert for this number of attempts,
-	// > File.d will fall with non-zero exit code or skip message (see fatal_on_failed_insert).
+	// > After an insert error, fall with a non-zero exit code or not. A configured deadqueue disables fatal exits.
 	Retry int `json:"retry" default:"0"` // *
 
 	// > @3@4@5@6

--- a/plugin/output/kafka/README.md
+++ b/plugin/output/kafka/README.md
@@ -1,6 +1,8 @@
 # Kafka output
 It sends the event batches to kafka brokers using `franz-go` lib.
 
+Supports [dead queue](/plugin/output/README.md#dead-queue).
+
 ### Config params
 **`brokers`** *`[]string`* *`required`* 
 
@@ -91,8 +93,7 @@ the client.ForceMetadataRefresh() function is used for some ProduceSync errors:
 
 **`fatal_on_failed_insert`** *`bool`* *`default=false`* 
 
-After an insert error, fall with a non-zero exit code or not
-**Experimental feature**
+After an insert error, fall with a non-zero exit code or not. A configured deadqueue disables fatal exits.
 
 <br>
 

--- a/plugin/output/kafka/kafka.go
+++ b/plugin/output/kafka/kafka.go
@@ -40,7 +40,7 @@ type Plugin struct {
 
 	// plugin metrics
 	sendErrorMetric prometheus.Counter
-	router          pipeline.Router
+	router          *pipeline.Router
 }
 
 // ! config-params
@@ -263,12 +263,12 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.OutputPluginP
 		MinRetention:         p.config.Retention_,
 		Multiplier:           float64(p.config.RetentionExponentMultiplier),
 		AttemptNum:           p.config.Retry,
-		DeadQueueIsAvailable: p.router.DeadQueueIsAvailable(),
+		IsDeadQueueAvailable: p.router.IsDeadQueueAvailable(),
 	}
 
 	onError := func(err error, events []*pipeline.Event) {
 		var level zapcore.Level
-		if p.config.FatalOnFailedInsert && !p.router.DeadQueueIsAvailable() {
+		if p.config.FatalOnFailedInsert && !p.router.IsDeadQueueAvailable() {
 			level = zapcore.FatalLevel
 		} else {
 			level = zapcore.ErrorLevel

--- a/plugin/output/kafka/kafka.go
+++ b/plugin/output/kafka/kafka.go
@@ -18,6 +18,8 @@ import (
 
 /*{ introduction
 It sends the event batches to kafka brokers using `franz-go` lib.
+
+Supports [dead queue](/plugin/output/README.md#dead-queue).
 }*/
 
 const (
@@ -127,8 +129,7 @@ type Config struct {
 
 	// > @3@4@5@6
 	// >
-	// > After an insert error, fall with a non-zero exit code or not
-	// > **Experimental feature**
+	// > After an insert error, fall with a non-zero exit code or not. A configured deadqueue disables fatal exits.
 	FatalOnFailedInsert bool `json:"fatal_on_failed_insert" default:"false"` // *
 
 	// > @3@4@5@6

--- a/plugin/output/kafka/kafka.go
+++ b/plugin/output/kafka/kafka.go
@@ -258,10 +258,12 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.OutputPluginP
 		MetricCtl:      params.MetricCtl,
 	}
 
+	p.router = params.Router
 	backoffOpts := pipeline.BackoffOpts{
-		MinRetention: p.config.Retention_,
-		Multiplier:   float64(p.config.RetentionExponentMultiplier),
-		AttemptNum:   p.config.Retry,
+		MinRetention:         p.config.Retention_,
+		Multiplier:           float64(p.config.RetentionExponentMultiplier),
+		AttemptNum:           p.config.Retry,
+		DeadQueueIsAvailable: p.router.DeadQueueIsAvailable(),
 	}
 
 	onError := func(err error, events []*pipeline.Event) {
@@ -289,7 +291,6 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.OutputPluginP
 	)
 
 	p.batcher.Start(context.TODO())
-	p.router = params.Router
 }
 
 func (p *Plugin) Out(event *pipeline.Event) {

--- a/plugin/output/loki/README.md
+++ b/plugin/output/loki/README.md
@@ -1,6 +1,8 @@
 # Loki output
 It sends the logs batches to Loki using HTTP API.
 
+Supports [dead queue](/plugin/output/README.md#dead-queue).
+
 ### Config params
 **`address`** *`string`* *`required`* 
 
@@ -137,8 +139,7 @@ File.d will fall with non-zero exit code or skip message (see fatal_on_failed_in
 
 **`fatal_on_failed_insert`** *`bool`* *`default=false`* 
 
-After an insert error, fall with a non-zero exit code or not
-**Experimental feature**
+After an insert error, fall with a non-zero exit code or not. A configured deadqueue disables fatal exits.
 
 <br>
 

--- a/plugin/output/loki/loki.go
+++ b/plugin/output/loki/loki.go
@@ -236,7 +236,7 @@ type Plugin struct {
 
 	labels map[string]string
 
-	router pipeline.Router
+	router *pipeline.Router
 }
 
 func init() {
@@ -277,12 +277,12 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.OutputPluginP
 		MinRetention:         p.config.Retention_,
 		Multiplier:           float64(p.config.RetentionExponentMultiplier),
 		AttemptNum:           p.config.Retry,
-		DeadQueueIsAvailable: p.router.DeadQueueIsAvailable(),
+		IsDeadQueueAvailable: p.router.IsDeadQueueAvailable(),
 	}
 
 	onError := func(err error, events []*pipeline.Event) {
 		var level zapcore.Level
-		if p.config.FatalOnFailedInsert && !p.router.DeadQueueIsAvailable() {
+		if p.config.FatalOnFailedInsert && !p.router.IsDeadQueueAvailable() {
 			level = zapcore.FatalLevel
 		} else {
 			level = zapcore.ErrorLevel

--- a/plugin/output/loki/loki.go
+++ b/plugin/output/loki/loki.go
@@ -276,7 +276,7 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.OutputPluginP
 		AttemptNum:   p.config.Retry,
 	}
 
-	onError := func(err error) {
+	onError := func(err error, _ []*pipeline.Event) {
 		var level zapcore.Level
 		if p.config.FatalOnFailedInsert {
 			level = zapcore.FatalLevel

--- a/plugin/output/loki/loki.go
+++ b/plugin/output/loki/loki.go
@@ -24,6 +24,8 @@ import (
 
 /*{ introduction
 It sends the logs batches to Loki using HTTP API.
+
+Supports [dead queue](/plugin/output/README.md#dead-queue).
 }*/
 
 var errUnixNanoFormat = errors.New("please send time in UnixNano format or add a convert_date action")
@@ -170,8 +172,7 @@ type Config struct {
 
 	// > @3@4@5@6
 	// >
-	// > After an insert error, fall with a non-zero exit code or not
-	// > **Experimental feature**
+	// > After an insert error, fall with a non-zero exit code or not. A configured deadqueue disables fatal exits.
 	FatalOnFailedInsert bool `json:"fatal_on_failed_insert" default:"false"` // *
 
 	// > @3@4@5@6

--- a/plugin/output/postgres/README.md
+++ b/plugin/output/postgres/README.md
@@ -1,6 +1,8 @@
 # Postgres output
 It sends the event batches to postgres db using pgx.
 
+Supports [dead queue](/plugin/output/README.md#dead-queue).
+
 ### Config params
 **`strict`** *`bool`* *`default=false`* 
 
@@ -47,8 +49,7 @@ File.d will fall with non-zero exit code or skip message (see fatal_on_failed_in
 
 **`fatal_on_failed_insert`** *`bool`* *`default=false`* 
 
-After an insert error, fall with a non-zero exit code or not
-**Experimental feature**
+After an insert error, fall with a non-zero exit code or not. A configured deadqueue disables fatal exits.
 
 <br>
 

--- a/plugin/output/postgres/postgres.go
+++ b/plugin/output/postgres/postgres.go
@@ -22,6 +22,8 @@ import (
 
 /*{ introduction
 It sends the event batches to postgres db using pgx.
+
+Supports [dead queue](/plugin/output/README.md#dead-queue).
 }*/
 
 /*{ example
@@ -164,8 +166,7 @@ type Config struct {
 
 	// > @3@4@5@6
 	// >
-	// > After an insert error, fall with a non-zero exit code or not
-	// > **Experimental feature**
+	// > After an insert error, fall with a non-zero exit code or not. A configured deadqueue disables fatal exits.
 	FatalOnFailedInsert bool `json:"fatal_on_failed_insert" default:"false"` // *
 
 	// > @3@4@5@6

--- a/plugin/output/postgres/postgres.go
+++ b/plugin/output/postgres/postgres.go
@@ -292,7 +292,7 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.OutputPluginP
 		AttemptNum:   p.config.Retry,
 	}
 
-	onError := func(err error) {
+	onError := func(err error, _ []*pipeline.Event) {
 		var level zapcore.Level
 		if p.config.FatalOnFailedInsert {
 			level = zapcore.FatalLevel

--- a/plugin/output/postgres/postgres.go
+++ b/plugin/output/postgres/postgres.go
@@ -112,7 +112,7 @@ type Plugin struct {
 	writtenEventMetric    prometheus.Counter
 	insertErrorsMetric    prometheus.Counter
 
-	router pipeline.Router
+	router *pipeline.Router
 }
 
 type ConfigColumn struct {
@@ -293,12 +293,12 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.OutputPluginP
 		MinRetention:         p.config.Retention_,
 		Multiplier:           float64(p.config.RetentionExponentMultiplier),
 		AttemptNum:           p.config.Retry,
-		DeadQueueIsAvailable: p.router.DeadQueueIsAvailable(),
+		IsDeadQueueAvailable: p.router.IsDeadQueueAvailable(),
 	}
 
 	onError := func(err error, events []*pipeline.Event) {
 		var level zapcore.Level
-		if p.config.FatalOnFailedInsert && !p.router.DeadQueueIsAvailable() {
+		if p.config.FatalOnFailedInsert && !p.router.IsDeadQueueAvailable() {
 			level = zapcore.FatalLevel
 		} else {
 			level = zapcore.ErrorLevel

--- a/plugin/output/s3/README.md
+++ b/plugin/output/s3/README.md
@@ -154,7 +154,6 @@ File.d will fall with non-zero exit code or skip message (see fatal_on_failed_in
 **`fatal_on_failed_insert`** *`bool`* *`default=false`* 
 
 After an insert error, fall with a non-zero exit code or not
-**Experimental feature**
 
 <br>
 

--- a/plugin/output/s3/s3.go
+++ b/plugin/output/s3/s3.go
@@ -244,7 +244,6 @@ type Config struct {
 	// > @3@4@5@6
 	// >
 	// > After an insert error, fall with a non-zero exit code or not
-	// > **Experimental feature**
 	FatalOnFailedInsert bool `json:"fatal_on_failed_insert" default:"false"` // *
 
 	// > @3@4@5@6

--- a/plugin/output/splunk/README.md
+++ b/plugin/output/splunk/README.md
@@ -47,6 +47,8 @@ Out:
 }
 ```
 
+Supports [dead queue](/plugin/output/README.md#dead-queue).
+
 ### Config params
 **`endpoint`** *`string`* *`required`* 
 
@@ -125,8 +127,7 @@ File.d will fall with non-zero exit code or skip message (see fatal_on_failed_in
 
 **`fatal_on_failed_insert`** *`bool`* *`default=false`* 
 
-After an insert error, fall with a non-zero exit code or not
-**Experimental feature**
+After an insert error, fall with a non-zero exit code or not. A configured deadqueue disables fatal exits.
 
 <br>
 

--- a/plugin/output/splunk/splunk.go
+++ b/plugin/output/splunk/splunk.go
@@ -68,6 +68,8 @@ Out:
   }
 }
 ```
+
+Supports [dead queue](/plugin/output/README.md#dead-queue).
 }*/
 
 const (
@@ -179,8 +181,7 @@ type Config struct {
 
 	// > @3@4@5@6
 	// >
-	// > After an insert error, fall with a non-zero exit code or not
-	// > **Experimental feature**
+	// > After an insert error, fall with a non-zero exit code or not. A configured deadqueue disables fatal exits.
 	FatalOnFailedInsert bool `json:"fatal_on_failed_insert" default:"false"` // *
 
 	// > @3@4@5@6

--- a/plugin/output/splunk/splunk.go
+++ b/plugin/output/splunk/splunk.go
@@ -97,7 +97,7 @@ type Plugin struct {
 	// plugin metrics
 	sendErrorMetric *prometheus.CounterVec
 
-	router pipeline.Router
+	router *pipeline.Router
 }
 
 type CopyField struct {
@@ -270,12 +270,12 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.OutputPluginP
 		MinRetention:         p.config.Retention_,
 		Multiplier:           float64(p.config.RetentionExponentMultiplier),
 		AttemptNum:           p.config.Retry,
-		DeadQueueIsAvailable: p.router.DeadQueueIsAvailable(),
+		IsDeadQueueAvailable: p.router.IsDeadQueueAvailable(),
 	}
 
 	onError := func(err error, events []*pipeline.Event) {
 		var level zapcore.Level
-		if p.config.FatalOnFailedInsert && !p.router.DeadQueueIsAvailable() {
+		if p.config.FatalOnFailedInsert && !p.router.IsDeadQueueAvailable() {
 			level = zapcore.FatalLevel
 		} else {
 			level = zapcore.ErrorLevel

--- a/plugin/output/splunk/splunk.go
+++ b/plugin/output/splunk/splunk.go
@@ -269,7 +269,7 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.OutputPluginP
 		AttemptNum:   p.config.Retry,
 	}
 
-	onError := func(err error) {
+	onError := func(err error, _ []*pipeline.Event) {
 		var level zapcore.Level
 		if p.config.FatalOnFailedInsert {
 			level = zapcore.FatalLevel

--- a/plugin/output/splunk/splunk.go
+++ b/plugin/output/splunk/splunk.go
@@ -96,6 +96,8 @@ type Plugin struct {
 
 	// plugin metrics
 	sendErrorMetric *prometheus.CounterVec
+
+	router pipeline.Router
 }
 
 type CopyField struct {
@@ -263,15 +265,17 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.OutputPluginP
 		MetricCtl:      params.MetricCtl,
 	}
 
+	p.router = params.Router
 	backoffOpts := pipeline.BackoffOpts{
-		MinRetention: p.config.Retention_,
-		Multiplier:   float64(p.config.RetentionExponentMultiplier),
-		AttemptNum:   p.config.Retry,
+		MinRetention:         p.config.Retention_,
+		Multiplier:           float64(p.config.RetentionExponentMultiplier),
+		AttemptNum:           p.config.Retry,
+		DeadQueueIsAvailable: p.router.DeadQueueIsAvailable(),
 	}
 
-	onError := func(err error, _ []*pipeline.Event) {
+	onError := func(err error, events []*pipeline.Event) {
 		var level zapcore.Level
-		if p.config.FatalOnFailedInsert {
+		if p.config.FatalOnFailedInsert && !p.router.DeadQueueIsAvailable() {
 			level = zapcore.FatalLevel
 		} else {
 			level = zapcore.ErrorLevel
@@ -279,6 +283,10 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.OutputPluginP
 
 		p.logger.Desugar().Log(level, "can't send data to splunk", zap.Error(err),
 			zap.Int("retries", p.config.Retry))
+
+		for i := range events {
+			p.router.Fail(events[i])
+		}
 	}
 
 	p.batcher = pipeline.NewRetriableBatcher(

--- a/plugin/output/stdout/stdout.go
+++ b/plugin/output/stdout/stdout.go
@@ -13,7 +13,7 @@ It writes events to stdout(also known as console).
 
 type Plugin struct {
 	controller pipeline.OutputPluginController
-	router     pipeline.Router
+	router     *pipeline.Router
 }
 
 type Config struct{}

--- a/plugin/output/stdout/stdout.go
+++ b/plugin/output/stdout/stdout.go
@@ -13,6 +13,7 @@ It writes events to stdout(also known as console).
 
 type Plugin struct {
 	controller pipeline.OutputPluginController
+	router     pipeline.Router
 }
 
 type Config struct{}
@@ -30,6 +31,7 @@ func Factory() (pipeline.AnyPlugin, pipeline.AnyConfig) {
 
 func (p *Plugin) Start(_ pipeline.AnyConfig, params *pipeline.OutputPluginParams) {
 	p.controller = params.Controller
+	p.router = params.Router
 }
 
 func (_ *Plugin) Stop() {}
@@ -38,4 +40,5 @@ func (p *Plugin) Out(event *pipeline.Event) {
 	// nolint: forbidigo
 	fmt.Println(event.Root.EncodeToString())
 	p.controller.Commit(event)
+	p.router.Ack(event)
 }

--- a/plugin/output/stdout/stdout.go
+++ b/plugin/output/stdout/stdout.go
@@ -40,5 +40,4 @@ func (p *Plugin) Out(event *pipeline.Event) {
 	// nolint: forbidigo
 	fmt.Println(event.Root.EncodeToString())
 	p.controller.Commit(event)
-	p.router.Ack(event)
 }

--- a/test/test.go
+++ b/test/test.go
@@ -210,6 +210,7 @@ func NewEmptyOutputPluginParams() *pipeline.OutputPluginParams {
 	return &pipeline.OutputPluginParams{
 		PluginDefaultParams: newDefaultParams(),
 		Logger:              newLogger().Named("output"),
+		Router:              pipeline.NewRouter(),
 	}
 }
 


### PR DESCRIPTION
# Description

When the main output fails, it goes into a dead queue

## Examples

### Dead queue to the reserve elasticsearch

```yaml
main_pipeline:
  input:
    type: kafka
    brokers:
      - kafka:9092
    topics:
      - logs
  output:
    type: elasticsearch
    workers_count: 32
    endpoints:
      - http://elasticsearch-1:9200
    # route to reserve elasticsearch
    deadqueue:
      endpoints:
        - http://elasticsearch-2:9200
      type: elasticsearch
```

### Dead queue with second kafka topic and low priority consumer

```yaml
main_pipeline:
  input:
    type: kafka
    brokers:
      - kafka:9092
    topics:
      - logs
  output:
    type: elasticsearch
    workers_count: 32
    endpoints:
      - http://elasticsearch:9200
    # route to deadqueue pipeline
    deadqueue:
      brokers:
      - kafka:9092
      default_topic: logs-deadqueue
      type: kafka

deadqueue_pipeline:
  input:
    type: kafka
    brokers:
      - kafka:9092
    topics:
      - logs-deadqueue
  output:
    type: elasticsearch
    workers_count: 1 # low priority
    fatal_on_failed_insert: false
    endpoints:
      - http://elasticsearch:9200
```