### PR TITLE
Bug: do not set GOOS and GOARCH in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,13 @@ TIME := $(shell date '+%Y-%m-%d_%H:%M:%S')
 UPSTREAM_BRANCH ?= origin/master
 
 GOLANGCI_LINT_VER=latest
+GOOS ?= linux
+GOARCH ?= amd64
 
 .PHONY: build
 build: 
-	echo "Building for amd64..."
-	GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "-X github.com/ozontech/file.d/buildinfo.Version=${VERSION}" -o file.d ./cmd/file.d
+	echo "Building for $(GOOS) $(GOARCH)..."
+	go build -trimpath -ldflags "-X github.com/ozontech/file.d/buildinfo.Version=${VERSION}" -o file.d ./cmd/file.d
 
 .PHONY: cover
 cover:


### PR DESCRIPTION
# Description

Updated Makefile not to set GOOS and GOARCH env vars in go build

Fixes #889