### PR TITLE
Add int value cmp in do_if

### DIFF
--- a/pipeline/doif/README.md
+++ b/pipeline/doif/README.md
@@ -298,7 +298,7 @@ DoIf length comparison op node is considered to always be a leaf in the DoIf tre
 It contains operation that compares field length in bytes or array length (for array fields) with certain value.
 
 Params:
-  - `op` - must be `byte_len_cmp` or `array_len_cmp`. Required.
+  - `op` - must be `byte_len_cmp`, `array_len_cmp` or `int_val_cmp`. Required.
   - `field` - name of the field to apply operation. Required.
   - `cmp_op` - comparison operation name (see below). Required.
   - `value` - integer value to compare length with. Required non-negative.

--- a/pipeline/doif/do_if_test.go
+++ b/pipeline/doif/do_if_test.go
@@ -968,6 +968,35 @@ func TestCheck(t *testing.T) {
 			},
 		},
 		{
+			name: "int_val_cmp_ok",
+			tree: treeNode{
+				lenCmpOp:  intValCmpOpTag,
+				cmpOp:     "ge",
+				fieldName: "count",
+				cmpValue:  50,
+			},
+			data: []argsResp{
+				{`{"count":50}`, true},
+				{`{"count":51}`, true},
+				{`{"count":49}`, false},
+			},
+		},
+		{
+			name: "int_val_cmp_not_int",
+			tree: treeNode{
+				lenCmpOp:  intValCmpOpTag,
+				cmpOp:     "ge",
+				fieldName: "count",
+				cmpValue:  0,
+			},
+			data: []argsResp{
+				{`{"count":"0"}`, true},
+				{`{"count":"n"}`, false},
+				{`{"count":[0]}`, false},
+				{`{"not_count":0}`, false},
+			},
+		},
+		{
 			name: "ts_cmp_lt",
 			tree: treeNode{
 				tsCmpOp:            true,


### PR DESCRIPTION
# Description

This pull request adds int_val_cmp operation in do_if. It allows parsing field value as int and compare it with some constant integer value.

Fixes #894 