### PR TITLE
update http output pugin

### DIFF
--- a/plugin/output/http/http.go
+++ b/plugin/output/http/http.go
@@ -151,6 +151,12 @@ type Config struct {
 
 	// > @3@4@5@6
 	// >
+	// > Enable partial shipment big batches
+	// > Only one flag out of two (SplitBatch or ItemizeBatch) can be initialized
+	ItemizeBatch bool `json:"itemize_batch" default:"false"` // *
+
+	// > @3@4@5@6
+	// >
 	// > Retention milliseconds for retry to DB.
 	Retention  cfg.Duration `json:"retention" default:"1s" parse:"duration"` // *
 	Retention_ time.Duration
@@ -334,9 +340,12 @@ func (p *Plugin) out(workerData *pipeline.WorkerData, batch *pipeline.Batch) err
 	var statusCode int
 	var err error
 
-	if p.config.SplitBatch {
+	switch true {
+	case p.config.SplitBatch:
 		statusCode, err = p.sendSplit(0, eventsCount, data.begin, data.outBuf)
-	} else {
+	case p.config.ItemizeBatch:
+		statusCode, err = p.sendItemize(0, eventsCount, data.begin, data.outBuf)
+	default:
 		statusCode, err = p.send(data.outBuf)
 	}
 
@@ -405,6 +414,40 @@ func (p *Plugin) sendSplit(left int, right int, begin []int, data []byte) (int, 
 	}
 
 	return http.StatusOK, nil
+}
+
+func (p *Plugin) sendItemize(left int, right int, begin []int, data []byte) (statusCode int, err error) {
+	statusCode = http.StatusOK
+	err = nil
+	if left == right {
+		return statusCode, err
+	}
+
+	for i := left; i < right; i++ {
+		sc, r := p.client.DoTimeout(
+			http.MethodPost,
+			p.config.ContentType,
+			data[begin[i]:begin[i+1]],
+			p.config.ConnectionTimeout_,
+			nil)
+		if r != nil {
+			p.sendErrorMetric.WithLabelValues(strconv.Itoa(sc)).Inc()
+
+			switch sc {
+			case http.StatusRequestEntityTooLarge:
+				// can't save even one log
+				if right-i == 1 {
+					statusCode = sc
+					err = r
+				}
+			default:
+				statusCode = sc
+				err = r
+			}
+		}
+	}
+
+	return statusCode, err
 }
 
 func (p *Plugin) getAuthHeader() string {


### PR DESCRIPTION
# Description

Когда не было http output плагина, мне пришлось реализовать свой. Я взял за основу output плагин elasticsearch.
Http плагин был необходим для передачи логов Куба (kube api) в CS (container security) по http. Т.e. мне надо было через file.d имитировать работу kube api audit-log webhooks.  

Базовая настройка kube-api через webhook предполагает такую работу:
kube-api может разово передавать пачку событий формата
```
Batch = {
    {event 1},
    {event 2}, 
    ... 
    {event n} 
}
```
где: |Batch| = webhookMaxBatchSize, |event i| = maxEventSize.

А filed (да и все другие агенты) отправляет пачку событий формата:
```
Batch = {event 1},{event 2},...,{event n}
```
Таким образом, массив не упакован в { }, а это не валидный json и функция json.Unmarshal в плагине CS валится с ошибкой.

Поэтому filed был настроен так, чтобы отправлять одним постом один event: |Batch| = |event|.

Настройка заключается в том, что я в свой http output добавил (помимо сплитования) флаг поэлементной отправки данных массива логов (событий).

Чтобы перейти на ваш плагин, нам нужен параметр itemize_batch. В текущем PR добавлен флаг itemize_batch и функция обработки массива логов.

Fixes # (issue)