### PR TITLE
fix: flush accumulated buffer on EOF without trailing newline

### DIFF
--- a/plugin/input/file/worker.go
+++ b/plugin/input/file/worker.go
@@ -202,6 +202,14 @@ func (w *worker) work(controller inputer, jobProvider *jobProvider, readBufferSi
 		job.tail = append(job.tail[:0], accumBuf...)
 		job.curOffset += readTotal
 
+		// Flush remaining data when EOF is reached and there's no trailing newline.
+		// Without this, the last line of a file that doesn't end with '\n' is silently dropped.
+		if isEOFReached && len(accumBuf) > 0 {
+			job.lastEventSeq = controller.In(sourceID, sourceName, pipeline.NewOffsets(lastOffset+scanned, offsets), accumBuf, isVirgin, metadataInfo)
+			accumBuf = accumBuf[:0]
+			job.tail = job.tail[:0]
+		}
+
 		// check if file was truncated.
 		if isEOFReached {
 			err := w.processEOF(file, job, jobProvider, lastOffset+readTotal)

--- a/plugin/input/file/worker.go
+++ b/plugin/input/file/worker.go
@@ -202,16 +202,16 @@ func (w *worker) work(controller inputer, jobProvider *jobProvider, readBufferSi
 		job.tail = append(job.tail[:0], accumBuf...)
 		job.curOffset += readTotal
 
-		// Flush remaining data when EOF is reached and there's no trailing newline.
-		// Without this, the last line of a file that doesn't end with '\n' is silently dropped.
-		if isEOFReached && len(accumBuf) > 0 {
-			job.lastEventSeq = controller.In(sourceID, sourceName, pipeline.NewOffsets(lastOffset+scanned, offsets), accumBuf, isVirgin, metadataInfo)
-			accumBuf = accumBuf[:0]
-			job.tail = job.tail[:0]
-		}
-
 		// check if file was truncated.
 		if isEOFReached {
+			// Flush remaining data when EOF is reached and there's no trailing newline.
+			// Without this, the last line of a file that doesn't end with '\n' is silently dropped.
+			if len(accumBuf) > 0 {
+				job.lastEventSeq = controller.In(sourceID, sourceName, pipeline.NewOffsets(lastOffset+scanned, offsets), accumBuf, isVirgin, metadataInfo)
+				accumBuf = accumBuf[:0]
+				job.tail = job.tail[:0]
+			}
+
 			err := w.processEOF(file, job, jobProvider, lastOffset+readTotal)
 			if err != nil {
 				logger.Fatalf("file %d:%s stat error: %s", sourceID, sourceName, err.Error())

--- a/plugin/input/file/worker_test.go
+++ b/plugin/input/file/worker_test.go
@@ -81,11 +81,18 @@ func TestWorkerWork(t *testing.T) {
 			expData:            "abc\n",
 		},
 		{
-			name:           "should_ok_when_read_1_line_without_newline",
+			name:           "should_emit_last_line_without_trailing_newline",
 			maxEventSize:   1024,
 			inFile:         "abc",
 			readBufferSize: 1024,
-			expData:        "",
+			expData:        "abc",
+		},
+		{
+			name:           "should_emit_last_line_among_multiple_without_trailing_newline",
+			maxEventSize:   1024,
+			inFile:         "line1\nline2\nline3",
+			readBufferSize: 1024,
+			expData:        "line3",
 		},
 	}
 	for _, tt := range tests {

--- a/plugin/input/file/worker_test.go
+++ b/plugin/input/file/worker_test.go
@@ -59,13 +59,6 @@ func TestWorkerWork(t *testing.T) {
 			expData:        "abc\n",
 		},
 		{
-			name:           "should_ok_and_empty_when_read_not_ready_line",
-			maxEventSize:   1024,
-			inFile:         "abc",
-			readBufferSize: 1024,
-			expData:        "",
-		},
-		{
 			name:           "should_ok_and_not_read_long_line",
 			maxEventSize:   2,
 			inFile:         "abc\n",
@@ -271,7 +264,7 @@ func TestWorkerWorkMultiData(t *testing.T) {
 			readBufferSize: 1024,
 
 			inData:  `{"a":"a"}`,
-			outData: nil, // we don't send an event if we don't find a newline
+			outData: []string{`{"a":"a"}`},
 		},
 	}
 


### PR DESCRIPTION
## Problem

When a file doesn't end with a newline character, the last line is silently dropped.

The read loop in `worker.go` accumulates data in `accumBuf` until it finds a `\n`. At EOF, the remaining data is saved to `job.tail` without ever being emitted through `controller.In()`. If the file is never written to again, that data is lost permanently.

**Steps to reproduce:**
1. Create a file with content that doesn't end with `\n`: `echo -n "hello" > /tmp/test.txt`
2. Configure file.d to read this file
3. The "hello" event is never emitted

## Fix

Emit `accumBuf` as a final event before calling `processEOF` when EOF is reached and the buffer is non-empty. Clear both `accumBuf` and `job.tail` afterward to prevent re-emission on file truncation.

**Changes:**
- `plugin/input/file/worker.go`: +8 lines — flush buffer on EOF
- `plugin/input/file/worker_test.go`: updated existing test expectation + added multi-line test case

Fixes #912