### PR TITLE
fix hash plugin quotes and brackets normalize

### DIFF
--- a/plugin/action/hash/hash.go
+++ b/plugin/action/hash/hash.go
@@ -449,7 +449,7 @@ func (p *Plugin) Do(event *pipeline.Event) pipeline.ActionResult {
 	case ffNo:
 		hash = calcHash(fieldData[:hashSize])
 	case ffNormalize:
-		hash = calcHash(p.normalizer.Normalize(p.buf, fieldData[:hashSize]))
+		hash = calcHash(p.normalizer.Normalize(p.buf, fieldData[:hashSize], hashSize != len(fieldData)))
 	}
 
 	pipeline.CreateNestedField(event.Root, p.config.ResultField_).MutateToUint64(hash)

--- a/plugin/action/hash/normalize/normalizer.go
+++ b/plugin/action/hash/normalize/normalizer.go
@@ -1,5 +1,5 @@
 package normalize
 
 type Normalizer interface {
-	Normalize(out, data []byte) []byte
+	Normalize(out, data []byte, cropped bool) []byte
 }

--- a/plugin/action/hash/normalize/token_normalizer.go
+++ b/plugin/action/hash/normalize/token_normalizer.go
@@ -163,12 +163,12 @@ func NewTokenNormalizer(params TokenNormalizerParams) (Normalizer, error) {
 	return n, nil
 }
 
-func (n *tokenNormalizer) Normalize(out, data []byte) []byte {
+func (n *tokenNormalizer) Normalize(out, data []byte, cropped bool) []byte {
 	out = out[:0]
 
 	var scanner *lexmachine.Scanner
 	if n.normalizeByBytes {
-		out = n.normalizeByTokenizer(out, newTokenizer(n.builtinPatterns, data))
+		out = n.normalizeByTokenizer(out, newTokenizer(n.builtinPatterns, data, cropped))
 		if n.lexer == nil {
 			return out
 		}
@@ -249,16 +249,18 @@ type token struct {
 
 func newToken(placeholder string) lexmachine.Action {
 	return func(s *lexmachine.Scanner, m *machines.Match) (any, error) {
+		begin, end := m.TC, m.TC+len(m.Bytes)
+
 		// skip `\w<match>\w`
-		if m.TC > 0 && isWord(s.Text[m.TC-1]) ||
-			m.TC+len(m.Bytes) < len(s.Text) && isWord(s.Text[m.TC+len(m.Bytes)]) {
+		if begin > 0 && isWord(s.Text[begin-1]) ||
+			end < len(s.Text) && isWord(s.Text[end]) {
 			return nil, nil
 		}
 
 		return token{
 			placeholder: placeholder,
-			begin:       m.TC,
-			end:         m.TC + len(m.Bytes),
+			begin:       begin,
+			end:         end,
 		}, nil
 	}
 }
@@ -288,6 +290,9 @@ func (n *tokenNormalizer) normalizeByScanner(out []byte, scanner *lexmachine.Sca
 func (n *tokenNormalizer) normalizeByTokenizer(out []byte, tok *tokenizer) []byte {
 	prevEnd := 0
 	for t, end := tok.nextToken(); !end; t, end = tok.nextToken() {
+		if t == nil {
+			continue
+		}
 		out = append(out, tok.data[prevEnd:t.begin]...)
 		out = append(out, t.placeholder...)
 		prevEnd = t.end
@@ -312,61 +317,64 @@ func hasPattern(patterns int, masks ...int) bool {
 type tokenizer struct {
 	patterns int
 	data     []byte
-	pos      int
+	cropped  bool
 
-	curPattern   int
-	counter      int
-	startPattern int
+	pos int
+
+	curPattern      int
+	startPatternPos int
+	counter         int
 }
 
-func newTokenizer(patterns int, data []byte) *tokenizer {
+func newTokenizer(patterns int, data []byte, cropped bool) *tokenizer {
 	return &tokenizer{
 		patterns: patterns,
 		data:     data,
+		cropped:  cropped,
 	}
 }
 
-func (t *tokenizer) nextToken() (token, bool) {
+func (t *tokenizer) nextToken() (*token, bool) {
 	t.curPattern = 0
 	t.counter = 0
-	t.startPattern = 0
+	t.startPatternPos = 0
 
 	for i := t.pos; i < len(t.data); i++ {
 		switch {
 		case t.data[i] == '{' && hasPattern(t.patterns, pCurlyBracketed):
 			t.processOpenBracket(pCurlyBracketed, i)
 		case t.data[i] == '}' && hasPattern(t.patterns, pCurlyBracketed):
-			if t, ok := t.processCloseBracket(pCurlyBracketed, i); ok {
-				return t, false
+			if tok := t.processCloseBracket(pCurlyBracketed, i); tok != nil {
+				return tok, false
 			}
 		case t.data[i] == '[' && hasPattern(t.patterns, pSquareBracketed):
 			t.processOpenBracket(pSquareBracketed, i)
 		case t.data[i] == ']' && hasPattern(t.patterns, pSquareBracketed):
-			if t, ok := t.processCloseBracket(pSquareBracketed, i); ok {
-				return t, false
+			if tok := t.processCloseBracket(pSquareBracketed, i); tok != nil {
+				return tok, false
 			}
 		case t.data[i] == '(' && hasPattern(t.patterns, pParenthesized):
 			t.processOpenBracket(pParenthesized, i)
 		case t.data[i] == ')' && hasPattern(t.patterns, pParenthesized):
-			if t, ok := t.processCloseBracket(pParenthesized, i); ok {
-				return t, false
+			if tok := t.processCloseBracket(pParenthesized, i); tok != nil {
+				return tok, false
 			}
 		case t.data[i] == '"' && hasPattern(t.patterns, pDoubleQuoted):
-			t, shift, ok := t.processQuotes('"', pDoubleQuoted, i)
-			if ok {
-				return t, false
+			tok, shift := t.processQuotes('"', pDoubleQuoted, i)
+			if tok != nil {
+				return tok, false
 			}
 			i += shift
 		case t.data[i] == '\'' && hasPattern(t.patterns, pSingleQuoted):
-			t, shift, ok := t.processQuotes('\'', pSingleQuoted, i)
-			if ok {
-				return t, false
+			tok, shift := t.processQuotes('\'', pSingleQuoted, i)
+			if tok != nil {
+				return tok, false
 			}
 			i += shift
 		case t.data[i] == '`' && hasPattern(t.patterns, pGraveQuoted):
-			t, shift, ok := t.processQuotes('`', pGraveQuoted, i)
-			if ok {
-				return t, false
+			tok, shift := t.processQuotes('`', pGraveQuoted, i)
+			if tok != nil {
+				return tok, false
 			}
 			i += shift
 		}
@@ -374,61 +382,73 @@ func (t *tokenizer) nextToken() (token, bool) {
 
 	// last partial token for possible cropped data
 	if t.curPattern != 0 {
-		t.pos = len(t.data)
-		return token{
-			placeholder: placeholderByPattern[t.curPattern],
-			begin:       t.startPattern,
-			end:         t.pos,
-		}, false
+		var tok *token
+		if t.cropped { // if data was cropped - return partial token
+			t.pos = len(t.data)
+			tok = &token{
+				placeholder: placeholderByPattern[t.curPattern],
+				begin:       t.startPatternPos,
+				end:         t.pos,
+			}
+		} else { // otherwise check again from next pos
+			t.pos = t.startPatternPos + 1
+		}
+		return tok, false
 	}
 
-	return token{}, true
+	return nil, true
 }
 
 func (t *tokenizer) processOpenBracket(pattern int, pos int) {
 	if t.curPattern == 0 {
 		t.curPattern = pattern
 		t.counter = 1
-		t.startPattern = pos
+		t.startPatternPos = pos
 	} else if t.curPattern == pattern {
 		t.counter++
 	}
 }
 
-func (t *tokenizer) processCloseBracket(pattern int, pos int) (token, bool) {
+func (t *tokenizer) processCloseBracket(pattern int, pos int) *token {
 	if t.curPattern != pattern {
-		return token{}, false
+		return nil
 	}
 
 	t.counter--
 	if t.counter > 0 {
-		return token{}, false
+		return nil
 	}
 
 	t.pos = pos + 1
-	return token{
+	return &token{
 		placeholder: placeholderByPattern[pattern],
-		begin:       t.startPattern,
+		begin:       t.startPatternPos,
 		end:         t.pos,
-	}, true
+	}
 }
 
-func (t *tokenizer) processQuotes(c byte, pattern int, pos int) (token, int, bool) {
+func (t *tokenizer) processQuotes(c byte, pattern int, pos int) (*token, int) {
+	// skip `\w<quote>\w`
+	if pos > 0 && isWord(t.data[pos-1]) &&
+		pos+1 < len(t.data) && isWord(t.data[pos+1]) {
+		return nil, 0
+	}
+
 	if t.curPattern == 0 {
 		t.curPattern = pattern
 		t.counter = 1
-		t.startPattern = pos
+		t.startPatternPos = pos
 
 		// multiple quotes in a row
 		for i := pos + 1; i < len(t.data) && t.data[i] == c; i++ {
 			t.counter++
 		}
 
-		return token{}, t.counter - 1, false
+		return nil, t.counter - 1
 	} else if t.curPattern == pattern {
 		// skip escaped
 		if pos > 0 && t.data[pos-1] == '\\' {
-			return token{}, 0, false
+			return nil, 0
 		}
 
 		tmp := t.counter - 1
@@ -437,17 +457,17 @@ func (t *tokenizer) processQuotes(c byte, pattern int, pos int) (token, int, boo
 			tmp--
 		}
 		if tmp > 0 {
-			return token{}, t.counter - tmp - 1, false
+			return nil, t.counter - tmp - 1
 		}
 
 		t.pos = pos + t.counter
-		return token{
+		return &token{
 			placeholder: placeholderByPattern[pattern],
-			begin:       t.startPattern,
+			begin:       t.startPatternPos,
 			end:         t.pos,
-		}, 0, true
+		}, 0
 	}
-	return token{}, 0, false
+	return nil, 0
 }
 
 func isWord(c byte) bool {

--- a/plugin/action/hash/normalize/token_normalizer_test.go
+++ b/plugin/action/hash/normalize/token_normalizer_test.go
@@ -112,8 +112,11 @@ func TestNormalizeByBytesOnly(t *testing.T) {
 	tests := []struct {
 		name string
 
-		input []string
-		want  string
+		input   []string
+		cropped bool
+
+		want     string
+		wantSame bool
 	}{
 		{
 			name:  "curly_brackets",
@@ -158,14 +161,37 @@ func TestNormalizeByBytesOnly(t *testing.T) {
 			want: "some <grave_quoted> here",
 		},
 		{
-			name:  "partial_token1",
-			input: []string{`some "dsadsadasd asd qw`},
-			want:  "some <double_quoted>",
+			name: "quotes_wordwrap",
+			input: []string{
+				`Can't breath h'e'r'e`,
+				`Can"t breath h"e"r"e`,
+				"Can`t breath h`e`r`e",
+			},
+			wantSame: true,
 		},
 		{
-			name:  "partial_token2",
-			input: []string{`some {"a":1,b:{"c":2,"d":3},e:[4,5,6]`},
-			want:  "some <curly_bracketed>",
+			name:    "partial_token_quotes_cropped",
+			input:   []string{`some "dsadsadasd asd qw`},
+			cropped: true,
+			want:    "some <double_quoted>",
+		},
+		{
+			name:     "partial_token_quotes_not_cropped",
+			input:    []string{`some "dsadsadasd asd qw`},
+			cropped:  false,
+			wantSame: true,
+		},
+		{
+			name:    "partial_token_brackets_cropped",
+			input:   []string{`some {"a":1,b:{"c":2,"d":3},e:[4,5,6]`},
+			cropped: true,
+			want:    "some <curly_bracketed>",
+		},
+		{
+			name:    "partial_token_brackets_not_cropped",
+			input:   []string{`some {"a":1,b:{"c":2,"d":3},e:[4,5,6]`},
+			cropped: false,
+			want:    `some {<double_quoted>:1,b:<curly_bracketed>,e:<square_bracketed>`,
 		},
 		{
 			name:  "multiple",
@@ -188,8 +214,13 @@ func TestNormalizeByBytesOnly(t *testing.T) {
 			out := make([]byte, 0)
 
 			for _, i := range tt.input {
-				out = n.Normalize(out, []byte(i))
-				assert.Equal(t, tt.want, string(out), "wrong out with input=%q", i)
+				out = n.Normalize(out, []byte(i), tt.cropped)
+
+				if tt.wantSame {
+					assert.Equal(t, i, string(out), "wrong out with input=%q", i)
+				} else {
+					assert.Equal(t, tt.want, string(out), "wrong out with input=%q", i)
+				}
 			}
 		})
 	}
@@ -422,7 +453,7 @@ func TestTokenNormalizerBuiltin(t *testing.T) {
 			out := make([]byte, 0)
 
 			for _, i := range tt.inputs {
-				out = n.Normalize(out, []byte(i))
+				out = n.Normalize(out, []byte(i), false)
 				assert.Equal(t, tt.want, string(out), "wrong out with input=%q", i)
 			}
 		})
@@ -496,6 +527,8 @@ func TestTokenNormalizerCustom(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			n, err := NewTokenNormalizer(tt.params)
 			require.Equal(t, tt.wantErr, err != nil || n == nil)
 			if tt.wantErr {
@@ -503,7 +536,7 @@ func TestTokenNormalizerCustom(t *testing.T) {
 			}
 
 			for _, i := range tt.inputs {
-				out = n.Normalize(out, []byte(i))
+				out = n.Normalize(out, []byte(i), false)
 				assert.Equal(t, tt.want, string(out), "wrong out with input=%q", i)
 			}
 		})
@@ -553,7 +586,7 @@ func BenchmarkTokenNormalizer(b *testing.B) {
 		name := fmt.Sprintf("input_len_%d", len(benchCase.input))
 		b.Run(name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				out = n.Normalize(out, benchCase.input)
+				out = n.Normalize(out, benchCase.input, false)
 			}
 		})
 	}


### PR DESCRIPTION
# Description

- Fix normalizing quotes in words
- Add `cropped` flag for partial token normalization logic