### PR TITLE
fix: data race in convert_utf8_bytes plugin

### DIFF
--- a/plugin/action/convert_utf8_bytes/convert_utf8_bytes.go
+++ b/plugin/action/convert_utf8_bytes/convert_utf8_bytes.go
@@ -105,7 +105,6 @@ The resulting event:
 type Plugin struct {
 	config *Config
 	fields [][]string
-	buf    []byte
 }
 
 // ! config-params
@@ -152,14 +151,14 @@ func (p *Plugin) Do(event *pipeline.Event) pipeline.ActionResult {
 		if node == nil || !node.IsString() {
 			continue
 		}
-		p.convert(node)
+		p.convert(event, node)
 	}
 
 	return pipeline.ActionPass
 }
 
-func (p *Plugin) convert(node *insaneJSON.Node) {
-	p.buf = p.buf[:0]
+func (p *Plugin) convert(event *pipeline.Event, node *insaneJSON.Node) {
+	buf := event.Buf[:0]
 
 	nodeStr := node.AsString()
 
@@ -167,7 +166,7 @@ func (p *Plugin) convert(node *insaneJSON.Node) {
 	if idx < 0 {
 		return
 	}
-	p.buf = append(p.buf, nodeStr[:idx]...)
+	buf = append(buf, nodeStr[:idx]...)
 	nodeStr = nodeStr[idx+1:]
 
 	for nodeStr != "" {
@@ -175,7 +174,7 @@ func (p *Plugin) convert(node *insaneJSON.Node) {
 		switch ch {
 		case '\\':
 			nodeStr = nodeStr[1:]
-			p.buf = append(p.buf, `\\`...)
+			buf = append(buf, `\\`...)
 		// unicode
 		case 'u', 'U':
 			nodeStr = nodeStr[1:]
@@ -186,14 +185,14 @@ func (p *Plugin) convert(node *insaneJSON.Node) {
 			}
 
 			if len(nodeStr) < size {
-				p.buf = append(p.buf, '\\', ch)
+				buf = append(buf, '\\', ch)
 				break
 			}
 
 			ss := nodeStr[:size]
 			u, err := strconv.ParseUint(ss, 16, 64)
 			if err != nil {
-				p.buf = append(p.buf, '\\', ch)
+				buf = append(buf, '\\', ch)
 				break
 			}
 
@@ -205,33 +204,33 @@ func (p *Plugin) convert(node *insaneJSON.Node) {
 
 			// '\U...' or 1-byte '\u...'
 			if size == 8 || !utf16.IsSurrogate(rune(u)) {
-				p.buf = append(p.buf, string(rune(u))...)
+				buf = append(buf, string(rune(u))...)
 				break
 			}
 
 			if len(nodeStr) < 6 || nodeStr[:2] != `\u` {
-				p.buf = append(p.buf, `\u`...)
-				p.buf = append(p.buf, ss...)
+				buf = append(buf, `\u`...)
+				buf = append(buf, ss...)
 				break
 			}
 
 			// 2-byte '\u...\u...'
 			u2, err := strconv.ParseUint(nodeStr[2:6], 16, 64)
 			if err != nil {
-				p.buf = append(p.buf, `\u`...)
-				p.buf = append(p.buf, ss...)
+				buf = append(buf, `\u`...)
+				buf = append(buf, ss...)
 				break
 			}
 
 			r := utf16.DecodeRune(rune(u), rune(u2))
-			p.buf = append(p.buf, string(r)...)
+			buf = append(buf, string(r)...)
 			nodeStr = nodeStr[6:]
 		// hex
 		case 'x':
 			nodeStr = nodeStr[1:]
 
 			if len(nodeStr) < 2 {
-				p.buf = append(p.buf, `\x`...)
+				buf = append(buf, `\x`...)
 				break
 			}
 
@@ -254,39 +253,40 @@ func (p *Plugin) convert(node *insaneJSON.Node) {
 
 			hexBytes, err := hex.DecodeString(sb.String())
 			if err != nil {
-				p.buf = append(p.buf, `\x`...)
-				p.buf = append(p.buf, nodeStr[:pos]...)
+				buf = append(buf, `\x`...)
+				buf = append(buf, nodeStr[:pos]...)
 			} else {
-				p.buf = append(p.buf, hexBytes...)
+				buf = append(buf, hexBytes...)
 			}
 			nodeStr = nodeStr[pos:]
 		// octal
 		case '0', '1', '2', '3':
 			if len(nodeStr) < 3 {
-				p.buf = append(p.buf, '\\')
+				buf = append(buf, '\\')
 				break
 			}
 
 			u, err := strconv.ParseUint(nodeStr[:3], 8, 64)
 			if err != nil {
-				p.buf = append(p.buf, '\\')
+				buf = append(buf, '\\')
 				break
 			}
 
-			p.buf = append(p.buf, byte(u))
+			buf = append(buf, byte(u))
 			nodeStr = nodeStr[3:]
 		default:
-			p.buf = append(p.buf, '\\')
+			buf = append(buf, '\\')
 		}
 
-		idx = strings.IndexByte(nodeStr, '\\')
+		idx := strings.IndexByte(nodeStr, '\\')
 		if idx < 0 {
-			p.buf = append(p.buf, nodeStr...)
+			buf = append(buf, nodeStr...)
 			break
 		}
-		p.buf = append(p.buf, nodeStr[:idx]...)
+		buf = append(buf, nodeStr[:idx]...)
 		nodeStr = nodeStr[idx+1:]
 	}
 
-	node.MutateToString(pipeline.ByteToStringUnsafe(p.buf))
+	event.Buf = buf
+	node.MutateToString(pipeline.ByteToStringUnsafe(buf))
 }

--- a/plugin/action/convert_utf8_bytes/convert_utf8_bytes.go
+++ b/plugin/action/convert_utf8_bytes/convert_utf8_bytes.go
@@ -105,6 +105,7 @@ The resulting event:
 type Plugin struct {
 	config *Config
 	fields [][]string
+	buf    []byte
 }
 
 // ! config-params
@@ -151,14 +152,14 @@ func (p *Plugin) Do(event *pipeline.Event) pipeline.ActionResult {
 		if node == nil || !node.IsString() {
 			continue
 		}
-		p.convert(event, node)
+		p.convert(node)
 	}
 
 	return pipeline.ActionPass
 }
 
-func (p *Plugin) convert(event *pipeline.Event, node *insaneJSON.Node) {
-	buf := event.Buf[:0]
+func (p *Plugin) convert(node *insaneJSON.Node) {
+	p.buf = p.buf[:0]
 
 	nodeStr := node.AsString()
 
@@ -166,7 +167,7 @@ func (p *Plugin) convert(event *pipeline.Event, node *insaneJSON.Node) {
 	if idx < 0 {
 		return
 	}
-	buf = append(buf, nodeStr[:idx]...)
+	p.buf = append(p.buf, nodeStr[:idx]...)
 	nodeStr = nodeStr[idx+1:]
 
 	for nodeStr != "" {
@@ -174,7 +175,7 @@ func (p *Plugin) convert(event *pipeline.Event, node *insaneJSON.Node) {
 		switch ch {
 		case '\\':
 			nodeStr = nodeStr[1:]
-			buf = append(buf, `\\`...)
+			p.buf = append(p.buf, `\\`...)
 		// unicode
 		case 'u', 'U':
 			nodeStr = nodeStr[1:]
@@ -185,14 +186,14 @@ func (p *Plugin) convert(event *pipeline.Event, node *insaneJSON.Node) {
 			}
 
 			if len(nodeStr) < size {
-				buf = append(buf, '\\', ch)
+				p.buf = append(p.buf, '\\', ch)
 				break
 			}
 
 			ss := nodeStr[:size]
 			u, err := strconv.ParseUint(ss, 16, 64)
 			if err != nil {
-				buf = append(buf, '\\', ch)
+				p.buf = append(p.buf, '\\', ch)
 				break
 			}
 
@@ -204,33 +205,33 @@ func (p *Plugin) convert(event *pipeline.Event, node *insaneJSON.Node) {
 
 			// '\U...' or 1-byte '\u...'
 			if size == 8 || !utf16.IsSurrogate(rune(u)) {
-				buf = append(buf, string(rune(u))...)
+				p.buf = append(p.buf, string(rune(u))...)
 				break
 			}
 
 			if len(nodeStr) < 6 || nodeStr[:2] != `\u` {
-				buf = append(buf, `\u`...)
-				buf = append(buf, ss...)
+				p.buf = append(p.buf, `\u`...)
+				p.buf = append(p.buf, ss...)
 				break
 			}
 
 			// 2-byte '\u...\u...'
 			u2, err := strconv.ParseUint(nodeStr[2:6], 16, 64)
 			if err != nil {
-				buf = append(buf, `\u`...)
-				buf = append(buf, ss...)
+				p.buf = append(p.buf, `\u`...)
+				p.buf = append(p.buf, ss...)
 				break
 			}
 
 			r := utf16.DecodeRune(rune(u), rune(u2))
-			buf = append(buf, string(r)...)
+			p.buf = append(p.buf, string(r)...)
 			nodeStr = nodeStr[6:]
 		// hex
 		case 'x':
 			nodeStr = nodeStr[1:]
 
 			if len(nodeStr) < 2 {
-				buf = append(buf, `\x`...)
+				p.buf = append(p.buf, `\x`...)
 				break
 			}
 
@@ -253,40 +254,39 @@ func (p *Plugin) convert(event *pipeline.Event, node *insaneJSON.Node) {
 
 			hexBytes, err := hex.DecodeString(sb.String())
 			if err != nil {
-				buf = append(buf, `\x`...)
-				buf = append(buf, nodeStr[:pos]...)
+				p.buf = append(p.buf, `\x`...)
+				p.buf = append(p.buf, nodeStr[:pos]...)
 			} else {
-				buf = append(buf, hexBytes...)
+				p.buf = append(p.buf, hexBytes...)
 			}
 			nodeStr = nodeStr[pos:]
 		// octal
 		case '0', '1', '2', '3':
 			if len(nodeStr) < 3 {
-				buf = append(buf, '\\')
+				p.buf = append(p.buf, '\\')
 				break
 			}
 
 			u, err := strconv.ParseUint(nodeStr[:3], 8, 64)
 			if err != nil {
-				buf = append(buf, '\\')
+				p.buf = append(p.buf, '\\')
 				break
 			}
 
-			buf = append(buf, byte(u))
+			p.buf = append(p.buf, byte(u))
 			nodeStr = nodeStr[3:]
 		default:
-			buf = append(buf, '\\')
+			p.buf = append(p.buf, '\\')
 		}
 
-		idx := strings.IndexByte(nodeStr, '\\')
+		idx = strings.IndexByte(nodeStr, '\\')
 		if idx < 0 {
-			buf = append(buf, nodeStr...)
+			p.buf = append(p.buf, nodeStr...)
 			break
 		}
-		buf = append(buf, nodeStr[:idx]...)
+		p.buf = append(p.buf, nodeStr[:idx]...)
 		nodeStr = nodeStr[idx+1:]
 	}
 
-	event.Buf = buf
-	node.MutateToString(pipeline.ByteToStringUnsafe(buf))
+	node.MutateToString(pipeline.ByteToStringUnsafe(p.buf))
 }

--- a/plugin/action/convert_utf8_bytes/convert_utf8_bytes.go
+++ b/plugin/action/convert_utf8_bytes/convert_utf8_bytes.go
@@ -152,13 +152,13 @@ func (p *Plugin) Do(event *pipeline.Event) pipeline.ActionResult {
 		if node == nil || !node.IsString() {
 			continue
 		}
-		p.convert(node)
+		p.convert(event.Root, node)
 	}
 
 	return pipeline.ActionPass
 }
 
-func (p *Plugin) convert(node *insaneJSON.Node) {
+func (p *Plugin) convert(root *insaneJSON.Root, node *insaneJSON.Node) {
 	p.buf = p.buf[:0]
 
 	nodeStr := node.AsString()
@@ -288,5 +288,5 @@ func (p *Plugin) convert(node *insaneJSON.Node) {
 		nodeStr = nodeStr[idx+1:]
 	}
 
-	node.MutateToString(pipeline.ByteToStringUnsafe(p.buf))
+	node.MutateToBytesCopy(root, p.buf)
 }

--- a/plugin/action/convert_utf8_bytes/convert_utf8_bytes_test.go
+++ b/plugin/action/convert_utf8_bytes/convert_utf8_bytes_test.go
@@ -81,10 +81,10 @@ func TestConvertUTF8Bytes(t *testing.T) {
 					"obj2",
 				},
 			},
-			in: `{"obj":{"field":"\xD0\xA1\xD0\x98\xD0\xA1\xD0\xA2\xD0\x95\xD0\x9C\xD0\x90.xml"},"obj2":"test\u003F\uD801\uDC01"}`,
+			in: `{"obj":{"field":"\xD0\xA1\xD0\x98\xD0\xA1\xD0\xA2\xD0\x95\xD0\x9C\xD0\x90.xml1"},"obj2":"\xD0\xA1\xD0\x98\xD0\xA1\xD0\xA2\xD0\x95\xD0\x9C\xD0\x90.xml2"}`,
 			wantFields: []string{
-				"СИСТЕМА.xml",
-				"test?𐐁",
+				"СИСТЕМА.xml1",
+				"СИСТЕМА.xml2",
 			},
 		},
 		{


### PR DESCRIPTION
# Description

The plugin reused a single p.buf buffer across events, causing a race
when concurrent processors modified it while outputs were encoding.
Fixed by using per-event event.Buf instead of plugin-shared p.buf.

```
WARNING: DATA RACE
Read at 0x00c00512a000 by goroutine 72:
  github.com/ozontech/insane-json.escapeString()
      github.com/ozontech/insane-json@v0.1.9/insane.go:2026 +0x3f2
  github.com/ozontech/insane-json.(*Node).Encode()
      github.com/ozontech/insane-json@v0.1.9/insane.go:660 +0x7ee
  github.com/ozontech/file.d/pipeline.(*Event).Encode()
      github.com/ozontech/file.d/pipeline/event.go:167 +0x75
  github.com/ozontech/file.d/encoder.(*JSONEncoder).Encode()
      github.com/ozontech/file.d/encoder/json.go:14 +0x3b
  github.com/ozontech/file.d/plugin/output/http.(*Plugin).out.func1()
      github.com/ozontech/file.d/plugin/output/http/http.go:392 +0x6a5
  github.com/ozontech/file.d/pipeline.(*Batch).ForEach()
      github.com/ozontech/file.d/pipeline/batch.go:106 +0x980
  github.com/ozontech/file.d/plugin/output/http.(*Plugin).out()
      github.com/ozontech/file.d/plugin/output/http/http.go:388 +0x473
  github.com/ozontech/file.d/plugin/output/http.(*Plugin).out-fm()
      <autogenerated>:1 +0x3e
  github.com/ozontech/file.d/pipeline.(*RetriableBatcher).Out()
      github.com/ozontech/file.d/pipeline/backoff.go:58 +0x248
  github.com/ozontech/file.d/pipeline.(*RetriableBatcher).Out-fm()
      <autogenerated>:1 +0x3e
  github.com/ozontech/file.d/pipeline.(*Batcher).work()
      github.com/ozontech/file.d/pipeline/batch.go:207 +0x268
  github.com/ozontech/file.d/pipeline.(*Batcher).Start.gowrap1()
      github.com/ozontech/file.d/pipeline/batch.go:189 +0x2e

Previous write at 0x00c00512a000 by goroutine 74:
  runtime.slicecopy()
      runtime/slice.go:392 +0x0
  github.com/ozontech/file.d/plugin/action/convert_utf8_bytes.(*Plugin).convert()
      github.com/ozontech/file.d/plugin/action/convert_utf8_bytes/convert_utf8_bytes.go:170 +0x157
  github.com/ozontech/file.d/plugin/action/convert_utf8_bytes.(*Plugin).Do()
      github.com/ozontech/file.d/plugin/action/convert_utf8_bytes/convert_utf8_bytes.go:155 +0x14b
  github.com/ozontech/file.d/pipeline.(*processor).doActions()
      github.com/ozontech/file.d/pipeline/processor.go:206 +0x236
  github.com/ozontech/file.d/pipeline.(*processor).processEvent()
      github.com/ozontech/file.d/pipeline/processor.go:170 +0x6b
  github.com/ozontech/file.d/pipeline.(*processor).processSequence()
      github.com/ozontech/file.d/pipeline/processor.go:149 +0x34
  github.com/ozontech/file.d/pipeline.(*processor).dischargeStream()
      github.com/ozontech/file.d/pipeline/processor.go:141 +0x44
  github.com/ozontech/file.d/pipeline.(*processor).process()
      github.com/ozontech/file.d/pipeline/processor.go:129 +0x64
  github.com/ozontech/file.d/pipeline.(*processor).start.gowrap1()
      github.com/ozontech/file.d/pipeline/processor.go:118 +0x2e
```