### PR TITLE
Rework loggerByPipeline map in debug action plugin

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -308,6 +308,13 @@ For example,
 This will log the first 10 events in a one second interval as-is.
 Following that, it will allow through every 5th event in that interval.
 
+If it is needed to log every entry, logger without sampling can be used,
+
+```yaml
+- type: debug
+  interval: 0s
+```
+
 
 [More details...](plugin/action/debug/README.md)
 ## decode

--- a/plugin/action/README.md
+++ b/plugin/action/README.md
@@ -129,6 +129,13 @@ For example,
 This will log the first 10 events in a one second interval as-is.
 Following that, it will allow through every 5th event in that interval.
 
+If it is needed to log every entry, logger without sampling can be used,
+
+```yaml
+- type: debug
+  interval: 0s
+```
+
 
 [More details...](plugin/action/debug/README.md)
 ## decode

--- a/plugin/action/debug/README.md
+++ b/plugin/action/debug/README.md
@@ -17,17 +17,40 @@ For example,
 This will log the first 10 events in a one second interval as-is.
 Following that, it will allow through every 5th event in that interval.
 
+If it is needed to log every entry, logger without sampling can be used,
+
+```yaml
+- type: debug
+  interval: 0s
+```
+
 
 ### Config params
 **`interval`** *`cfg.Duration`* 
+
+Tick interval for sampling logging. The first N entries with a given level and message
+each tick. If more Entries with the same level and message are seen during
+the same interval, every Mth message is logged and the rest are dropped.
+
+If set to 0, plugin uses parent logger without sampling.
+
+Check the example above for more information.
 
 <br>
 
 **`first`** *`int`* 
 
+Specifies the first N entries with a given level and message each tick.
+
+Check the example above for more information.
+
 <br>
 
 **`thereafter`** *`int`* 
+
+Specifies entries frequency after the first N entries.
+If greater than 0, every Mth message is logged and the rest are dropped.
+If set to 0, every entry after the first N are dropped.
 
 Check the example above for more information.
 

--- a/plugin/action/debug/debug.go
+++ b/plugin/action/debug/debug.go
@@ -34,6 +34,13 @@ For example,
 This will log the first 10 events in a one second interval as-is.
 Following that, it will allow through every 5th event in that interval.
 
+If it is needed to log every entry, logger without sampling can be used,
+
+```yaml
+- type: debug
+  interval: 0s
+```
+
 }*/
 
 type Plugin struct {
@@ -46,11 +53,27 @@ type Plugin struct {
 // ^ config-params
 type Config struct {
 	// > @3@4@5@6
+	// >
+	// > Tick interval for sampling logging. The first N entries with a given level and message
+	// > each tick. If more Entries with the same level and message are seen during
+	// > the same interval, every Mth message is logged and the rest are dropped.
+	// >
+	// > If set to 0, plugin uses parent logger without sampling.
+	// >
+	// > Check the example above for more information.
 	Interval  cfg.Duration `json:"interval" parse:"duration"` // *
 	Interval_ time.Duration
 	// > @3@4@5@6
+	// >
+	// > Specifies the first N entries with a given level and message each tick.
+	// >
+	// > Check the example above for more information.
 	First int `json:"first"` // *
 	// > @3@4@5@6
+	// >
+	// > Specifies entries frequency after the first N entries.
+	// > If greater than 0, every Mth message is logged and the rest are dropped.
+	// > If set to 0, every entry after the first N are dropped.
 	// >
 	// > Check the example above for more information.
 	Thereafter int `json:"thereafter"` // *
@@ -106,6 +129,7 @@ func (p *Plugin) Stop() {
 func (p *Plugin) setupLogger(parentLogger *zap.Logger, config *Config) {
 	if config.Interval_ == 0 {
 		p.logger = parentLogger
+		return
 	}
 
 	loggerByPipelineMu.Lock()

--- a/plugin/action/debug/debug.go
+++ b/plugin/action/debug/debug.go
@@ -2,6 +2,7 @@ package debug
 
 import (
 	"encoding/json"
+	"fmt"
 	"sync"
 	"time"
 
@@ -36,9 +37,9 @@ Following that, it will allow through every 5th event in that interval.
 }*/
 
 type Plugin struct {
-	logger       *zap.Logger
-	config       *Config
-	pipelineName string
+	logger         *zap.Logger
+	config         *Config
+	pipelineAction string
 }
 
 // ! config-params
@@ -74,7 +75,7 @@ func factory() (pipeline.AnyPlugin, pipeline.AnyConfig) {
 
 func (p *Plugin) Start(anyConfig pipeline.AnyConfig, params *pipeline.ActionPluginParams) {
 	p.config = anyConfig.(*Config)
-	p.pipelineName = params.PipelineName
+	p.pipelineAction = fmt.Sprintf("%s_%d", params.PipelineName, params.Index)
 
 	lg := params.Logger.Desugar()
 	p.setupLogger(lg, p.config)
@@ -91,14 +92,14 @@ func (p *Plugin) Do(event *pipeline.Event) pipeline.ActionResult {
 }
 
 var (
-	loggerByPipeline   = make(map[string]*zap.Logger)
-	loggerByPipelineMu sync.Mutex
+	loggerByPipelineAction = make(map[string]*zap.Logger)
+	loggerByPipelineMu     sync.Mutex
 )
 
 func (p *Plugin) Stop() {
 	loggerByPipelineMu.Lock()
 	defer loggerByPipelineMu.Unlock()
-	delete(loggerByPipeline, p.pipelineName)
+	delete(loggerByPipelineAction, p.pipelineAction)
 }
 
 // return shared logger between concurrent running processors
@@ -110,13 +111,13 @@ func (p *Plugin) setupLogger(parentLogger *zap.Logger, config *Config) {
 	loggerByPipelineMu.Lock()
 	defer loggerByPipelineMu.Unlock()
 
-	lg, ok := loggerByPipeline[p.pipelineName]
+	lg, ok := loggerByPipelineAction[p.pipelineAction]
 	if !ok {
 		// enable sampler
 		lg = parentLogger.WithOptions(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
 			return zapcore.NewSamplerWithOptions(parentLogger.Core(), config.Interval_, config.First, config.Thereafter)
 		}))
-		loggerByPipeline[p.pipelineName] = lg
+		loggerByPipelineAction[p.pipelineAction] = lg
 	}
 	p.logger = lg
 }

--- a/plugin/action/debug/debug_test.go
+++ b/plugin/action/debug/debug_test.go
@@ -28,6 +28,7 @@ func TestLogger(t *testing.T) {
 	}
 
 	const pipelineName = "logd"
+	const pipelineAction = pipelineName + "_0"
 	p.Start(&c, &pipeline.ActionPluginParams{
 		PluginDefaultParams: pipeline.PluginDefaultParams{
 			PipelineName: pipelineName,
@@ -36,7 +37,7 @@ func TestLogger(t *testing.T) {
 	})
 
 	loggerByPipelineMu.Lock()
-	_, ok := loggerByPipeline[pipelineName]
+	_, ok := loggerByPipelineAction[pipelineAction]
 	r.True(ok)
 	loggerByPipelineMu.Unlock()
 


### PR DESCRIPTION
# Description

Rework loggerByPipeline map in debug action plugin so it stores loggers by pipeline and action index. With this two or more debug plugins in the same pipeline utilize different loggers with different settings.

Fixes #1006