### PR TITLE
Fix parsing substitutions for modify

### DIFF
--- a/cfg/substitution/substitution.go
+++ b/cfg/substitution/substitution.go
@@ -82,14 +82,9 @@ func ParseSubstitution(substitution string, filtersBuf []byte, logger *zap.Logge
 			break
 		}
 
-		if len(substitution) < pos+1 {
-			substitution = substitution[pos+1:]
-			continue
-		}
-
 		switch substitution[pos+1] {
 		case '$':
-			tail = substitution[:pos+1]
+			tail += substitution[:pos+1]
 			substitution = substitution[pos+2:]
 		case '{':
 			// append SubstitutionOpKindRaw only if there is non-empty content
@@ -128,7 +123,7 @@ func ParseSubstitution(substitution string, filtersBuf []byte, logger *zap.Logge
 
 			substitution = substitution[end+1:]
 		default:
-			tail = substitution[:pos+1]
+			tail += substitution[:pos+1]
 			substitution = substitution[pos+1:]
 		}
 	}

--- a/cfg/substitution/substitution.go
+++ b/cfg/substitution/substitution.go
@@ -108,8 +108,9 @@ func ParseSubstitution(substitution string, filtersBuf []byte, logger *zap.Logge
 
 			var filterOps []FieldFilter
 			selectorEnd := end
-			pipe := indexRuneInExpr(substitution, '|', true, false)
+			pipe := indexRuneInExpr(substitution[pos+2:end], '|', true, false)
 			if pipe != -1 {
+				pipe += pos + 2 // correct pipe pos in substitution
 				selectorEnd = pipe
 				filterOps, err = parseFilterOps(substitution, pipe, end, filtersBuf, logger)
 				if err != nil {

--- a/cfg/substitution/substitution_test.go
+++ b/cfg/substitution/substitution_test.go
@@ -45,6 +45,38 @@ func TestParseSubstitution(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:         "no_filter_two_fields",
+			substitution: `${a.b} - ${c.d}`,
+			data: [][]string{
+				{"a", "b"},
+				{" - "},
+				{"c", "d"},
+			},
+			wantErr: false,
+		},
+		{
+			name:         "no_filter_two_fields_with_curly_brackets",
+			substitution: `{ ${a.b} : ${c.d} }`,
+			data: [][]string{
+				{"{ "},
+				{"a", "b"},
+				{" : "},
+				{"c", "d"},
+				{" }"},
+			},
+			wantErr: false,
+		},
+		{
+			name:         "no_filter_two_fields_with_pipe",
+			substitution: `${a.b} | ${c.d}`,
+			data: [][]string{
+				{"a", "b"},
+				{" | "},
+				{"c", "d"},
+			},
+			wantErr: false,
+		},
+		{
 			name:         "no_filter_field_no_ending",
 			substitution: `days till world end ${prediction.days}`,
 			data: [][]string{
@@ -110,6 +142,31 @@ func TestParseSubstitution(t *testing.T) {
 					},
 				},
 				nil,
+			},
+			wantErr: false,
+		},
+		{
+			name:         "with_filter_two_fields_and_pipe",
+			substitution: `${a.b|trim("all","\\n")} | ${c.d|trim("all","\\n")}`,
+			data: [][]string{
+				{"a", "b"},
+				{" | "},
+				{"c", "d"},
+			},
+			filters: [][][]any{
+				{
+					{
+						trimModeAll,
+						"\\n",
+					},
+				},
+				nil,
+				{
+					{
+						trimModeAll,
+						"\\n",
+					},
+				},
 			},
 			wantErr: false,
 		},

--- a/cfg/substitution/substitution_test.go
+++ b/cfg/substitution/substitution_test.go
@@ -460,6 +460,14 @@ func TestParseSubstitution(t *testing.T) {
 			substitution: `test ${field|trim_to("first",-10)} test2`,
 			wantErr:      true,
 		},
+		{
+			name:         "test_many_special_symbols",
+			substitution: `test1 $ test2 $$ test3 $ test4`,
+			data: [][]string{
+				{"test1 $ test2 $ test3 $ test4"},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/plugin/action/modify/modify_test.go
+++ b/plugin/action/modify/modify_test.go
@@ -17,6 +17,7 @@ func TestModify(t *testing.T) {
 		"my_object.field.subfield":         "${existing_field}",
 		"my_object.new_field.new_subfield": "new_subfield_value",
 		"not_exists":                       "${not_existing_field}",
+		"from_two_fields":                  "${existing_field} | ${another_field}",
 	}, nil)
 	p, input, output := test.NewPipelineMock(test.NewActionPluginStaticInfo(factory, config, pipeline.MatchModeAnd, nil, false))
 	wg := &sync.WaitGroup{}
@@ -27,10 +28,11 @@ func TestModify(t *testing.T) {
 		assert.Equal(t, "existing_value", e.Root.Dig("my_object", "field", "subfield").AsString(), "wrong event field")
 		assert.Equal(t, "new_subfield_value", e.Root.Dig("my_object", "new_field", "new_subfield").AsString(), "wrong event field")
 		assert.Nil(t, e.Root.Dig("not_exists"), "wrong event field")
+		assert.Equal(t, "existing_value | another_value", e.Root.Dig("from_two_fields").AsString(), "wrong event field")
 		wg.Done()
 	})
 
-	input.In(0, "test.log", test.NewOffset(0), []byte(`{"existing_field":"existing_value","my_object":{"field":{"subfield":"subfield_value"}}}`))
+	input.In(0, "test.log", test.NewOffset(0), []byte(`{"existing_field":"existing_value","my_object":{"field":{"subfield":"subfield_value"}},"another_field":"another_value"}`))
 
 	wg.Wait()
 	p.Stop()


### PR DESCRIPTION
# Description

This PR fixes parsing substitutions for modify plugin so it is possible to use pipe symbol "|" alongside field selectors.

Fixes #1007 