### PR TITLE
security: run file.d containers as non-root

### DIFF
--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -44,4 +44,6 @@ WORKDIR /file.d
 
 COPY --from=build /file.d/file.d /file.d/file.d
 
+USER 65532:65532
+
 CMD [ "./file.d" ]

--- a/build/package/Dockerfile.scratch
+++ b/build/package/Dockerfile.scratch
@@ -31,4 +31,6 @@ WORKDIR /file.d
 
 COPY --from=build /file.d/file.d /file.d/file.d
 
+USER 65532:65532
+
 CMD [ "./file.d" ]

--- a/build/package/Dockerfile_dev
+++ b/build/package/Dockerfile_dev
@@ -73,4 +73,6 @@ WORKDIR /file.d
 
 COPY --from=build /file.d/file.d /file.d/file.d
 
+USER 65532:65532
+
 CMD [ "./file.d" ]

--- a/build/package/Dockerfile_playground
+++ b/build/package/Dockerfile_playground
@@ -29,4 +29,6 @@ WORKDIR /file-d-playground
 
 COPY --from=build /file-d-playground/file-d-playground .
 
+USER 65532:65532
+
 CMD [ "./file-d-playground" ]

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,6 +17,10 @@ Mount config from /my-config.yaml and start `file.d` with this config: <br>
 
 Do not forget to set [the actual tag](https://github.com/ozontech/file.d/pkgs/container/file.d) of the image.
 
+The Docker images run as the non-root UID/GID `65532:65532`. Make sure that mounted
+configuration, offset, input, and output paths are readable or writable by this identity
+as required by the selected plugins.
+
 ## Helm-chart
 
 [Helm-chart](/charts/filed/README.md) and examples for Minikube


### PR DESCRIPTION
## Summary

Closes #987 by running all four runtime file.d images as the unprivileged UID/GID `65532:65532`:

- `build/package/Dockerfile`
- `build/package/Dockerfile.scratch`
- `build/package/Dockerfile_dev`
- `build/package/Dockerfile_playground`

The installation guide now also documents the required permissions for mounted configuration, offset, input, and output paths.

## Rationale

The runtime base image is configurable across Ubuntu, Alpine, Rocky Linux, and `scratch`. A distro-specific named user would require different setup commands and cannot be used directly with `scratch`, which has no `/etc/passwd`. A numeric UID/GID keeps the runtime identity consistent across all supported images without modifying the base image user database.

Running the process as non-root limits the impact of a possible container compromise and follows the principle of least privilege.

## Validation

- `git diff --check`
- verified that `USER 65532:65532` is present in the final runtime stage of each Dockerfile

Docker is not installed in the local environment, so image builds could not be run locally. No Go application code was changed.
